### PR TITLE
Reverse Proxy SSL Support / Security Improvements

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -25,8 +25,16 @@ fi
 
 if ! [ -e index.php -a -e wp-includes/version.php ]; then
 	echo >&2 "WordPress not found in $(pwd) - copying now..."
-	rsync --archive --one-file-system --quiet /usr/src/wordpress/ ./
+	rsync --archive --one-file-system --quiet --exclude='*.sh' --exclude='*.conf' --exclude='Dockerfile' /usr/src/wordpress/ ./
 	echo >&2 "Complete! WordPress has been successfully copied to $(pwd)"
+	cat >> wp-config.php <<'EOPHP'
+
+	// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
+	// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
+	if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+		$_SERVER['HTTPS'] = 'on';
+	}
+	EOPHP
 	if [ ! -e .htaccess ]; then
 		cat > .htaccess <<-'EOF'
 			RewriteEngine On


### PR DESCRIPTION
Shell scripts and configuration files are currently copied into ht root folder and accessible via apache if this container is linked to the web. At the least this reveals system configuration information.

Added a line to wp-config.php that allows the instance to support reverse proxied ssl connections.
