### PR TITLE
fix wp-config additions to be after copy default

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -27,14 +27,6 @@ if ! [ -e index.php -a -e wp-includes/version.php ]; then
 	echo >&2 "WordPress not found in $(pwd) - copying now..."
 	rsync --archive --one-file-system --quiet --exclude='*.sh' --exclude='*.conf' --exclude='Dockerfile' /usr/src/wordpress/ ./
 	echo >&2 "Complete! WordPress has been successfully copied to $(pwd)"
-	cat >> wp-config.php <<'EOPHP'
-
-	// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
-	// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
-	if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
-		$_SERVER['HTTPS'] = 'on';
-	}
-	EOPHP
 	if [ ! -e .htaccess ]; then
 		cat > .htaccess <<-'EOF'
 			RewriteEngine On
@@ -51,6 +43,14 @@ fi
 
 if [ ! -e wp-config.php ]; then
 	cp wp-config-sample.php wp-config.php
+	cat >> wp-config.php <<'EOPHP'
+
+// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
+// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+	$_SERVER['HTTPS'] = 'on';
+}
+EOPHP
 fi
 
 set_config() {


### PR DESCRIPTION
based on #1

``` console
$ docker build -t wordpress-pr .
Sending build context to Docker daemon 113.9 MB
Sending build context to Docker daemon 
Step 0 : FROM debian:jessie
 ---> 3593263a3873
Step 1 : RUN apt-get update && apt-get install -y   apache2   curl   libapache2-mod-php5   php5-curl   php5-gd   php5-mysql   rsync   wget
 ---> Using cache
 ---> 977e2594663d
Step 2 : RUN a2enmod rewrite
 ---> Using cache
 ---> d9e6ce7d20a0
Step 3 : RUN rm -rf /var/www/html && mkdir /var/www/html
 ---> Using cache
 ---> b92ee151a8f2
Step 4 : WORKDIR /var/www/html
 ---> Using cache
 ---> 01c48e055f52
Step 5 : ENV APACHE_CONFDIR /etc/apache2
 ---> Using cache
 ---> 2517f681ab4c
Step 6 : ENV APACHE_ENVVARS $APACHE_CONFDIR/envvars
 ---> Using cache
 ---> 8080e9b19543
Step 7 : ENV APACHE_RUN_USER www-data
 ---> Using cache
 ---> 62f7421569c0
Step 8 : ENV APACHE_RUN_GROUP www-data
 ---> Using cache
 ---> ae8f14b0a56a
Step 9 : ENV APACHE_RUN_DIR /var/run/apache2
 ---> Using cache
 ---> ae7a17559111
Step 10 : ENV APACHE_PID_FILE $APACHE_RUN_DIR/apache2.pid
 ---> Using cache
 ---> eea22d562d38
Step 11 : ENV APACHE_LOCK_DIR /var/lock/apache2
 ---> Using cache
 ---> ca1eb7121718
Step 12 : ENV APACHE_LOG_DIR /var/log/apache2
 ---> Using cache
 ---> 82064dff80b3
Step 13 : ENV LANG C
 ---> Using cache
 ---> f1833267b726
Step 14 : RUN mkdir -p $APACHE_RUN_DIR $APACHE_LOCK_DIR $APACHE_LOG_DIR
 ---> Using cache
 ---> 5d903948f4ad
Step 15 : RUN find "$APACHE_CONFDIR" -type f -exec sed -ri '  s!^(\s*CustomLog)\s+\S+!\1 /proc/self/fd/1!g;  s!^(\s*ErrorLog)\s+\S+!\1 /proc/self/fd/2!g; ' '{}' ';'
 ---> Using cache
 ---> 889f7a20da92
Step 16 : ADD . /usr/src/wordpress
 ---> 8732eb0b5ea2
Removing intermediate container 75fe65c8ee18
Step 17 : RUN cp /usr/src/wordpress/docker-apache.conf /etc/apache2/sites-available/wordpress.conf  && a2dissite 000-default  && a2ensite wordpress
 ---> Running in fdf742f85807
Site 000-default disabled.
To activate the new configuration, you need to run:
  service apache2 reload
Enabling site wordpress.
To activate the new configuration, you need to run:
  service apache2 reload
 ---> 86551681ea74
Removing intermediate container fdf742f85807
Step 18 : ENTRYPOINT ["/usr/src/wordpress/docker-entrypoint.sh"]
 ---> Running in 4bbaa555fd37
 ---> 090246ddc05c
Removing intermediate container 4bbaa555fd37
Step 19 : EXPOSE 80
 ---> Running in 3ee63927ef80
 ---> 96ef99be1d2e
Removing intermediate container 3ee63927ef80
Step 20 : CMD ["apache2", "-DFOREGROUND"]
 ---> Running in 0d5987a6b086
 ---> cfdbe14e3abf
Removing intermediate container 0d5987a6b086
Successfully built cfdbe14e3abf
```
