### PR TITLE
Correct SSL Reverse Proxy Support

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -43,14 +43,14 @@ fi
 
 if [ ! -e wp-config.php ]; then
 	cp wp-config-sample.php wp-config.php
-	cat >> wp-config.php <<'EOPHP'
-
-// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
-// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
-if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
-	$_SERVER['HTTPS'] = 'on';
-}
-EOPHP
+	sed -i -e "/define('WP_DEBUG'/r /dev/stdin" wp-config.php <<- 'EOPHP'
+	
+	// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
+	// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
+	if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+		$_SERVER['HTTPS'] = 'on';
+	}
+	EOPHP
 fi
 
 set_config() {


### PR DESCRIPTION
The previous modifications added the correct lines to wp-config, but it added them at the end of the file, after wordpress had been loaded. Modifications are supposed to be added before line 83 (in this version of WP). I've inserted the code into the correct position in the file using sed and a heredoc. Wordpress official docs also mentions correct placement of this directive here http://codex.wordpress.org/Function_Reference/is_ssl.

This is basically a correction to the changes made here 
https://github.com/docker-library/wordpress/pull/2/files
