### PR TITLE
Fix SSL lines adding to the wrong place in the config using awk to look for the "stop editing" line and adding our new stuff directly above that

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -42,14 +42,13 @@ fi
 # TODO handle WordPress upgrades magically in the same way, but only if wp-includes/version.php's $wp_version is less than /usr/src/wordpress/wp-includes/version.php's $wp_version
 
 if [ ! -e wp-config.php ]; then
-	cp wp-config-sample.php wp-config.php
-	cat >> wp-config.php <<'EOPHP'
-
+	awk '/^\/\*.*stop editing.*\*\/$/ && c == 0 { c = 1; system("cat") } { print }' wp-config-sample.php > wp-config.php <<'EOPHP'
 // If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
 // see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
 if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
 	$_SERVER['HTTPS'] = 'on';
 }
+
 EOPHP
 fi
 


### PR DESCRIPTION
Fixes #3

This way we're not relying on `WP_DEBUG` to stay at the bottom or even in the file at all - we're just looking for the "stop editing here" comment directly and adding ourselves directly above that.

cc @drewwestphal @yosifkit
