### PR TITLE
Set appropriate permission to files & directories

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -43,6 +43,11 @@ if ! [ -e index.php -a -e wp-includes/version.php ]; then
 	fi
 fi
 
+find . -type d -exec chmod 755 {} \;
+find . -type f -exec chmod 640 {} \;
+
+chmod 604 .htaccess
+
 # TODO handle WordPress upgrades magically in the same way, but only if wp-includes/version.php's $wp_version is less than /usr/src/wordpress/wp-includes/version.php's $wp_version
 
 if [ ! -e wp-config.php ]; then
@@ -92,6 +97,8 @@ for unique in "${UNIQUES[@]}"; do
 		set_config "$unique" "$(head -c1M /dev/urandom | sha1sum | cut -d' ' -f1)"
 	fi
 done
+
+chmod 400 wp-config.php
 
 TERM=dumb php -- "$WORDPRESS_DB_HOST" "$WORDPRESS_DB_USER" "$WORDPRESS_DB_PASSWORD" "$WORDPRESS_DB_NAME" <<'EOPHP'
 <?php


### PR DESCRIPTION
現在のレシピではファイルパーミッションの設定を一切行っていないため、セキュリティの面で問題があります。
docker-entrypoint.sh において、適切なパーミッションを設定するようにしました。
## Before

| File / Directory | Permission |
| --- | --- |
| all files | 644 |
| all directories | 755 |
## After

| File / Directory | Permission |
| --- | --- |
| .htaccess | 604 |
| wp-config.php | 400 |
| other files | 640 |
| other directories | 755 |
### REF
- [Hardering WordPress](http://codex.wordpress.org/Hardening_WordPress)
- [Changing File Permissions](http://codex.wordpress.org/Changing_File_Permissions)
