### PR TITLE
Change chown to www-data

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -114,6 +114,6 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 $mysql->close();
 EOPHP
 
-chown -R "$APACHE_RUN_USER:$APACHE_RUN_GROUP" .
+chown -R www-data:www-data .
 
 exec "$@"


### PR DESCRIPTION
The `$APACHE_RUN_*` environment variables went away when this image moved to the `php:apache` base image.

Fixes #20.
