### PR TITLE
Container does not start when a non-graceful shutdown occurs on the host machine 

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+
+if [ -f /var/run/apache2/apache2.pid ] ; then
+rm /var/run/apache2/apache2.pid 
+fi
+
 if [ -z "$MYSQL_PORT_3306_TCP" ]; then
 	echo >&2 'error: missing MYSQL_PORT_3306_TCP environment variable'
 	echo >&2 '  Did you forget to --link some_mysql_container:mysql ?'


### PR DESCRIPTION
To recreate the problem you need to run the container like normal then do a hard power off of your server. When  you turn the server back on the container will not start when you try to start it . This is due to a lingering .pid file 

error: 
httpd (pid 1) already running

In the entrypoint file I added some logic to remove the .pid file if the .pid file exists so that the pid file is removed when the container is started. 
