### PR TITLE
Disable apache directory indexes

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -33,6 +33,7 @@ if ! [ -e index.php -a -e wp-includes/version.php ]; then
 	echo >&2 "Complete! WordPress has been successfully copied to $(pwd)"
 	if [ ! -e .htaccess ]; then
 		cat > .htaccess <<-'EOF'
+			Options -Indexes
 			RewriteEngine On
 			RewriteBase /
 			RewriteRule ^index\.php$ - [L]


### PR DESCRIPTION
Disable apache directory indexes for example for `/wp-includes/` etc
in the default `.htaccess` (only if it does not exist, like before).