### PR TITLE
Fixes #43. Adds support for JPEG.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ RUN apt-get update && apt-get install -y rsync && rm -r /var/lib/apt/lists/*
 RUN a2enmod rewrite
 
 # install the PHP extensions we need
-RUN apt-get update && apt-get install -y libpng12-dev && rm -rf /var/lib/apt/lists/* \
-	&& docker-php-ext-install gd \
-	&& apt-get purge --auto-remove -y libpng12-dev
+RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev && rm -rf /var/lib/apt/lists/* \
+ 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
+	&& docker-php-ext-install gd
 RUN docker-php-ext-install mysqli
 
 VOLUME /var/www/html


### PR DESCRIPTION
The fix adds support for JPEG in GD. Had to run `docker-php-ext-configure` first in order to change the build parameters. Also, had to strip out the removal of `libpng`, as it is required with this setup.