### PR TITLE
Set WORDPRESS_DB_HOST to external DB

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ -n "$MYSQL_PORT_3306_TCP" ]; then
-	WORDPRESS_DB_HOST='mysql'
+	WORDPRESS_DB_HOST="${MYSQL_PORT_3306_TCP#tcp://}"
 fi
 
 if [ -z "$WORDPRESS_DB_HOST" ]; then


### PR DESCRIPTION
A [previous commit](https://github.com/docker-library/wordpress/commit/9aae24350b9c4ede3d5db9cdac1ba88c3202fe98) by @tianon seems to have broken the ability to connect to an external DB. This addresses that problem, but may or may not play well with using a linked DB.