### PR TITLE
htaccess: disable directory indexes

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -50,6 +50,7 @@ if ! [ -e index.php -a -e wp-includes/version.php ]; then
 			RewriteCond %{REQUEST_FILENAME} !-f
 			RewriteCond %{REQUEST_FILENAME} !-d
 			RewriteRule . /index.php [L]
+			Options -Indexes
 		EOF
 	fi
 fi


### PR DESCRIPTION
Leaving directory indexes enabled poses a security risk. The directory `/wp-content/uploads/` for example is browsable, which may reveal sensitive information.