### PR TITLE
Without entering to /var/www/html following tests will fail.

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -34,6 +34,7 @@ if [ -z "$WORDPRESS_DB_PASSWORD" ]; then
 	exit 1
 fi
 
+cd /var/www/html
 if ! [ -e index.php -a -e wp-includes/version.php ]; then
 	echo >&2 "WordPress not found in $(pwd) - copying now..."
 	if [ "$(ls -A)" ]; then


### PR DESCRIPTION
Hi,

I think there's a small error on the script which makes it overwrite the /var/www/html contents at every run. This is a problem if you have that directory on a volume for that directory, every time you start a new container that uses the same volume (--volumes-from) its contents will be overwritten. I think there's a 'cd /var/www/html' command missing before the tests over the wordpress files that makes them fail and the tarball is uncompressed again, overwriting the previous install.