### PR TITLE
Change permissions handling to be more conservative

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -18,7 +18,8 @@ ENV WORDPRESS_SHA1 9e9745bb8a1166622de866076eac73a49cb3eba0
 RUN curl -o wordpress.tar.gz -SL https://wordpress.org/wordpress-${WORDPRESS_UPSTREAM_VERSION}.tar.gz \
 	&& echo "$WORDPRESS_SHA1 *wordpress.tar.gz" | sha1sum -c - \
 	&& tar -xzf wordpress.tar.gz -C /usr/src/ \
-	&& rm wordpress.tar.gz
+	&& rm wordpress.tar.gz \
+	&& chown -R www-data:www-data /usr/src/wordpress
 
 COPY docker-entrypoint.sh /entrypoint.sh
 

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -56,6 +56,7 @@ if ! [ -e index.php -a -e wp-includes/version.php ]; then
 			</IfModule>
 			# END WordPress
 		EOF
+		chown www-data:www-data .htaccess
 	fi
 fi
 
@@ -70,6 +71,7 @@ if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROT
 }
 
 EOPHP
+	chown www-data:www-data wp-config.php
 fi
 
 set_config() {
@@ -139,7 +141,5 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 
 $mysql->close();
 EOPHP
-
-chown -R www-data:www-data .
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -56,6 +56,7 @@ if ! [ -e index.php -a -e wp-includes/version.php ]; then
 			</IfModule>
 			# END WordPress
 		EOF
+		chown www-data:www-data .htaccess
 	fi
 fi
 
@@ -70,6 +71,7 @@ if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROT
 }
 
 EOPHP
+	chown www-data:www-data wp-config.php
 fi
 
 set_config() {
@@ -139,7 +141,5 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 
 $mysql->close();
 EOPHP
-
-chown -R www-data:www-data .
 
 exec "$@"

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -16,7 +16,8 @@ ENV WORDPRESS_SHA1 9e9745bb8a1166622de866076eac73a49cb3eba0
 RUN curl -o wordpress.tar.gz -SL https://wordpress.org/wordpress-${WORDPRESS_UPSTREAM_VERSION}.tar.gz \
 	&& echo "$WORDPRESS_SHA1 *wordpress.tar.gz" | sha1sum -c - \
 	&& tar -xzf wordpress.tar.gz -C /usr/src/ \
-	&& rm wordpress.tar.gz
+	&& rm wordpress.tar.gz \
+	&& chown -R www-data:www-data /usr/src/wordpress
 
 COPY docker-entrypoint.sh /entrypoint.sh
 

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -56,6 +56,7 @@ if ! [ -e index.php -a -e wp-includes/version.php ]; then
 			</IfModule>
 			# END WordPress
 		EOF
+		chown www-data:www-data .htaccess
 	fi
 fi
 
@@ -70,6 +71,7 @@ if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROT
 }
 
 EOPHP
+	chown www-data:www-data wp-config.php
 fi
 
 set_config() {
@@ -139,7 +141,5 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 
 $mysql->close();
 EOPHP
-
-chown -R www-data:www-data .
 
 exec "$@"


### PR DESCRIPTION
This allows things like bind-mounting into `/var/www/html/wp-content/themes/example` and not clobbering host permissions, making theme development and testing much simpler (change PHP file on host, reload page, etc).