### PR TITLE
Add opcache, redis extensions and set reasonable config values

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -5,8 +5,18 @@ RUN a2enmod rewrite
 # install the PHP extensions we need
 RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev && rm -rf /var/lib/apt/lists/* \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-	&& docker-php-ext-install gd
-RUN docker-php-ext-install mysqli
+	&& docker-php-ext-install gd mysqli opcache
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=60'; \
+		echo 'opcache.fast_shutdown=1'; \
+		echo 'opcache.enable_cli=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 VOLUME /var/www/html
 

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -3,8 +3,18 @@ FROM php:5.6-fpm
 # install the PHP extensions we need
 RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev && rm -rf /var/lib/apt/lists/* \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-	&& docker-php-ext-install gd
-RUN docker-php-ext-install mysqli
+	&& docker-php-ext-install gd mysqli opcache
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=60'; \
+		echo 'opcache.fast_shutdown=1'; \
+		echo 'opcache.enable_cli=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 VOLUME /var/www/html
 


### PR DESCRIPTION
It's too much of a pain to enable caching for wordpress and I propose to make it a bit easier with this commit. redis support still needs additional work though: there is no wp backend by default (installation of plugin required) and some options have to be set in the wp-config. But at least with this commit activating caching is much easier as no new plugins have to be installed on top and the opcache is running by default.