### PR TITLE
Fix problem with patching wp-config.php

### DIFF
--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -100,7 +100,7 @@ EOPHP
 			start="^(\s*)$(sed_escape_lhs "$key")\s*="
 			end=";"
 		fi
-		sed -ri "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
+		sed -ri "s/($start\s*).*($end)\s*$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
 	}
 
 	set_config 'DB_HOST' "$WORDPRESS_DB_HOST"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -100,7 +100,7 @@ EOPHP
 			start="^(\s*)$(sed_escape_lhs "$key")\s*="
 			end=";"
 		fi
-		sed -ri "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
+		sed -ri "s/($start\s*).*($end)\s*$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
 	}
 
 	set_config 'DB_HOST' "$WORDPRESS_DB_HOST"

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -100,7 +100,7 @@ EOPHP
 			start="^(\s*)$(sed_escape_lhs "$key")\s*="
 			end=";"
 		fi
-		sed -ri "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
+		sed -ri "s/($start\s*).*($end)\s*$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
 	}
 
 	set_config 'DB_HOST' "$WORDPRESS_DB_HOST"


### PR DESCRIPTION
The wp-config.php seems to have trailing spaces on some
lines. I have modified the RE to also match this.

This should fix the problem that people are reporting
for a few days.