### PR TITLE
Add environment variable, "$WORDPRESS_SKIP_CREATE_DB_IF_NOT_EXISTS".

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -141,7 +141,10 @@ EOPHP
 		set_config 'WP_DEBUG' 1 boolean
 	fi
 
-	TERM=dumb php -- "$WORDPRESS_DB_HOST" "$WORDPRESS_DB_USER" "$WORDPRESS_DB_PASSWORD" "$WORDPRESS_DB_NAME" <<'EOPHP'
+	if [ "$WORDPRESS_SKIP_CREATE_DB_IF_NOT_EXISTS" == "true" ] ; then
+		echo "Skipping call to sql call, CREATE DATABASE IF NOT EXISTS"
+	else
+	    TERM=dumb php -- "$WORDPRESS_DB_HOST" "$WORDPRESS_DB_USER" "$WORDPRESS_DB_PASSWORD" "$WORDPRESS_DB_NAME" <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 
@@ -170,6 +173,7 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 
 $mysql->close();
 EOPHP
+	fi
 fi
 
 exec "$@"


### PR DESCRIPTION
This flag is useful when you already know the Database is created, and the mysql user doesn't have "CREATE DATABASE" permissions.

If a mysql user does not have permissions to execute "CREATE DATABASE" then this code previously caused an error even if the database already exists.
