### PR TITLE
Add env variable to handle wordpress subdirectory

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -40,6 +40,12 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		group="$(id -g)"
 	fi
 
+    # allow use subdirectory in the wordpress site url and home configs, like: http://localhost/blog
+	if ! [ -z "$WORDPRESS_SUBDIRECTORY" ]; then
+        mkdir -p $WORDPRESS_SUBDIRECTORY
+        cd $WORDPRESS_SUBDIRECTORY
+    fi
+
 	if ! [ -e index.php -a -e wp-includes/version.php ]; then
 		echo >&2 "WordPress not found in $PWD - copying now..."
 		if [ "$(ls -A)" ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -40,11 +40,13 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		group="$(id -g)"
 	fi
 
-    # allow use subdirectory in the wordpress site url and home configs, like: http://localhost/blog
+	# allow use subdirectory in the wordpress site url and home configs, like: http://localhost/blog
 	if ! [ -z "$WORDPRESS_SUBDIRECTORY" ]; then
-        mkdir -p $WORDPRESS_SUBDIRECTORY
-        cd $WORDPRESS_SUBDIRECTORY
-    fi
+		# force relative path
+		WORDPRESS_SUBDIRECTORY=`echo $WORDPRESS_SUBDIRECTORY | sed 's/^\///g'`
+		mkdir -p $WORDPRESS_SUBDIRECTORY
+		cd $WORDPRESS_SUBDIRECTORY
+	fi
 
 	if ! [ -e index.php -a -e wp-includes/version.php ]; then
 		echo >&2 "WordPress not found in $PWD - copying now..."


### PR DESCRIPTION
Allow to proper change wordpress subdirectory. When `$WORDPRESS_SUBDIRECTORY` is set, the wordpress files will be moved to the relative folder configured, e.g.

`$ WORDPRESS_SUBDIRECTORY=blog # or /blog`

All wordpress files will be at `/var/www/html/blog` and you can access it on http://localhost/blog.

Related to #131.
