### PR TITLE
Support unix domain sockets in the WORDPRESS_DB_HOST environment variable

### DIFF
--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -147,11 +147,16 @@ EOPHP
 
 $stderr = fopen('php://stderr', 'w');
 
-list($host, $port) = explode(':', $argv[1], 2);
+list($host, $port_or_socket) = explode(':', $argv[1], 2);
+if ( 0 !== strpos( $port_or_socket, '/' ) ) {
+  $port = (int)$port_or_socket;
+} else {
+  $socket = $port_or_socket;
+}
 
 $maxTries = 10;
 do {
-	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int)$port);
+	$mysql = new mysqli($host, $argv[2], $argv[3], '', $port, $socket);
 	if ($mysql->connect_error) {
 		fwrite($stderr, "\n" . 'MySQL Connection Error: (' . $mysql->connect_errno . ') ' . $mysql->connect_error . "\n");
 		--$maxTries;

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -147,11 +147,16 @@ EOPHP
 
 $stderr = fopen('php://stderr', 'w');
 
-list($host, $port) = explode(':', $argv[1], 2);
+list($host, $port_or_socket) = explode(':', $argv[1], 2);
+if ( 0 !== strpos( $port_or_socket, '/' ) ) {
+  $port = (int)$port_or_socket;
+} else {
+  $socket = $port_or_socket;
+}
 
 $maxTries = 10;
 do {
-	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int)$port);
+	$mysql = new mysqli($host, $argv[2], $argv[3], '', $port, $socket);
 	if ($mysql->connect_error) {
 		fwrite($stderr, "\n" . 'MySQL Connection Error: (' . $mysql->connect_errno . ') ' . $mysql->connect_error . "\n");
 		--$maxTries;

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -147,11 +147,16 @@ EOPHP
 
 $stderr = fopen('php://stderr', 'w');
 
-list($host, $port) = explode(':', $argv[1], 2);
+list($host, $port_or_socket) = explode(':', $argv[1], 2);
+if ( 0 !== strpos( $port_or_socket, '/' ) ) {
+  $port = (int)$port_or_socket;
+} else {
+  $socket = $port_or_socket;
+}
 
 $maxTries = 10;
 do {
-	$mysql = new mysqli($host, $argv[2], $argv[3], '', (int)$port);
+	$mysql = new mysqli($host, $argv[2], $argv[3], '', $port, $socket);
 	if ($mysql->connect_error) {
 		fwrite($stderr, "\n" . 'MySQL Connection Error: (' . $mysql->connect_errno . ') ' . $mysql->connect_error . "\n");
 		--$maxTries;


### PR DESCRIPTION
If the port begins with a `/`, use it as a socket.

Fixes #138 
