### PR TITLE
Update to WordPress 4.6.1

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -20,8 +20,8 @@ RUN { \
 
 VOLUME /var/www/html
 
-ENV WORDPRESS_VERSION 4.6
-ENV WORDPRESS_SHA1 830962689f350e43cd1a069f3a4f68a44c0339c8
+ENV WORDPRESS_VERSION 4.6.1
+ENV WORDPRESS_SHA1 027e065d30a64720624a7404a1820e6c6fff1202
 
 # upstream tarballs include ./wordpress/ so this gives us /usr/src/wordpress
 RUN curl -o wordpress.tar.gz -SL https://wordpress.org/wordpress-${WORDPRESS_VERSION}.tar.gz \

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -18,8 +18,8 @@ RUN { \
 
 VOLUME /var/www/html
 
-ENV WORDPRESS_VERSION 4.6
-ENV WORDPRESS_SHA1 830962689f350e43cd1a069f3a4f68a44c0339c8
+ENV WORDPRESS_VERSION 4.6.1
+ENV WORDPRESS_SHA1 027e065d30a64720624a7404a1820e6c6fff1202
 
 # upstream tarballs include ./wordpress/ so this gives us /usr/src/wordpress
 RUN curl -o wordpress.tar.gz -SL https://wordpress.org/wordpress-${WORDPRESS_VERSION}.tar.gz \


### PR DESCRIPTION
Given [wordpress 4.6.1 just dropped as a security release](https://wordpress.org/news/2016/09/wordpress-4-6-1-security-and-maintenance-release/), can we urgently merge the updated v4 image?
