### PR TITLE
Using wp-cli to easily handle updates and other features

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,5 +1,11 @@
 FROM php:5.6-apache
 
+ARG wp_version=latest
+ARG wp_locale=en_US
+
+ENV WP_BUILD_VERSION wp_version
+ENV WP_BUILD_LOCALE wp_locale
+
 RUN a2enmod rewrite expires
 
 # install the PHP extensions we need
@@ -20,17 +26,16 @@ RUN { \
 
 VOLUME /var/www/html
 
-ENV WORDPRESS_VERSION 4.6.1
-ENV WORDPRESS_SHA1 027e065d30a64720624a7404a1820e6c6fff1202
+RUN curl -o /usr/local/bin/wp -SL https://github.com/wp-cli/wp-cli/releases/download/v0.24.1/wp-cli-0.24.1.phar \
+	&& chmod +x /usr/local/bin/wp \
+	&& wp --info --allow-root
 
-# upstream tarballs include ./wordpress/ so this gives us /usr/src/wordpress
-RUN curl -o wordpress.tar.gz -SL https://wordpress.org/wordpress-${WORDPRESS_VERSION}.tar.gz \
-	&& echo "$WORDPRESS_SHA1 *wordpress.tar.gz" | sha1sum -c - \
-	&& tar -xzf wordpress.tar.gz -C /usr/src/ \
-	&& rm wordpress.tar.gz \
+RUN wp core download --path=/usr/src/wordpress --locale=$wp_locale --version=$wp_version --allow-root \
 	&& chown -R www-data:www-data /usr/src/wordpress
 
 COPY docker-entrypoint.sh /entrypoint.sh
+
+WORKDIR /var/www/html
 
 # grr, ENTRYPOINT resets CMD now
 ENTRYPOINT ["/entrypoint.sh"]

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,5 +1,6 @@
 FROM php:5.6-apache
 
+ARG php_ext
 ARG wp_version=latest
 ARG wp_locale=en_US
 
@@ -11,7 +12,7 @@ RUN a2enmod rewrite expires
 # install the PHP extensions we need
 RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev && rm -rf /var/lib/apt/lists/* \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-	&& docker-php-ext-install gd mysqli opcache
+	&& docker-php-ext-install gd mysqli opcache $php_ext
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -54,7 +54,18 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 	# defaults to WP_VERSION=latest
 	if [ wp core is-installed ]; then
 		wp core update --version=$WP_VERSION
-		# TODO handle plugin updates
+
+		# update all plugins
+		wp plugin update --all
+
+		# install plugins provided in the WORDPRESS_PLUGINS env variable
+		if [ "$WORDPRESS_PLUGINS" ]; then
+			for $plugin in $WORDPRESS_PLUGINS; do 
+				if ! $(wp plugin is-installed ${plugin}); then
+					wp plugin install $plugin
+				fi
+			done 
+		fi
 	fi
 
 	# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+# Alias for WP-cli to include arguments that we want to use everywhere
+shopt -s expand_aliases
+alias wp="wp --path=$DOCUMENT_ROOT --allow-root"
+
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 	: "${WORDPRESS_DB_HOST:=mysql}"
 	# if we're linked to MySQL and thus have credentials already, let's use them
@@ -45,7 +49,13 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		fi
 	fi
 
-	# TODO handle WordPress upgrades magically in the same way, but only if wp-includes/version.php's $wp_version is less than /usr/src/wordpress/wp-includes/version.php's $wp_version
+	# handle WordPress upgrades magically with wp-cli
+	# can be set through env on runtime or arg on build time
+	# defaults to WP_VERSION=latest
+	if [ wp core is-installed ]; then
+		wp core update --version=$WP_VERSION
+		# TODO handle plugin updates
+	fi
 
 	# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
 	# https://github.com/docker-library/wordpress/issues/116

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+# Alias for WP-cli to include arguments that we want to use everywhere
+shopt -s expand_aliases
+alias wp="wp --path=$DOCUMENT_ROOT --allow-root"
+
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 	: "${WORDPRESS_DB_HOST:=mysql}"
 	# if we're linked to MySQL and thus have credentials already, let's use them
@@ -45,8 +49,25 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		fi
 	fi
 
-	# TODO handle WordPress upgrades magically in the same way, but only if wp-includes/version.php's $wp_version is less than /usr/src/wordpress/wp-includes/version.php's $wp_version
+	# handle WordPress upgrades magically with wp-cli
+	# can be set through env on runtime or arg on build time
+	# defaults to WP_VERSION=latest
+	if [ wp core is-installed ]; then
+		wp core update --version=$WP_VERSION
 
+		# update all plugins
+		wp plugin update --all
+
+		# install plugins provided in the WORDPRESS_PLUGINS env variable
+		if [ "$WORDPRESS_PLUGINS" ]; then
+			for $plugin in $WORDPRESS_PLUGINS; do 
+				if ! $(wp plugin is-installed ${plugin}); then
+					wp plugin install $plugin
+				fi
+			done 
+		fi
+	fi
+	
 	# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
 	# https://github.com/docker-library/wordpress/issues/116
 	# https://github.com/WordPress/WordPress/commit/1acedc542fba2482bab88ec70d4bea4b997a92e4

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -1,9 +1,16 @@
 FROM php:5.6-fpm
 
+ARG php_ext
+ARG wp_version=latest
+ARG wp_locale=en_US
+
+ENV WP_BUILD_VERSION wp_version
+ENV WP_BUILD_LOCALE wp_locale
+
 # install the PHP extensions we need
 RUN apt-get update && apt-get install -y libpng12-dev libjpeg-dev && rm -rf /var/lib/apt/lists/* \
 	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-	&& docker-php-ext-install gd mysqli opcache
+	&& docker-php-ext-install gd mysqli opcache $php_ext
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php
@@ -18,17 +25,16 @@ RUN { \
 
 VOLUME /var/www/html
 
-ENV WORDPRESS_VERSION 4.6.1
-ENV WORDPRESS_SHA1 027e065d30a64720624a7404a1820e6c6fff1202
+RUN curl -o /usr/local/bin/wp -SL https://github.com/wp-cli/wp-cli/releases/download/v0.24.1/wp-cli-0.24.1.phar \
+	&& chmod +x /usr/local/bin/wp \
+	&& wp --info --allow-root
 
-# upstream tarballs include ./wordpress/ so this gives us /usr/src/wordpress
-RUN curl -o wordpress.tar.gz -SL https://wordpress.org/wordpress-${WORDPRESS_VERSION}.tar.gz \
-	&& echo "$WORDPRESS_SHA1 *wordpress.tar.gz" | sha1sum -c - \
-	&& tar -xzf wordpress.tar.gz -C /usr/src/ \
-	&& rm wordpress.tar.gz \
+RUN wp core download --path=/usr/src/wordpress --locale=$wp_locale --version=$wp_version --allow-root \
 	&& chown -R www-data:www-data /usr/src/wordpress
 
 COPY docker-entrypoint.sh /entrypoint.sh
+
+WORKDIR /var/www/html
 
 # grr, ENTRYPOINT resets CMD now
 ENTRYPOINT ["/entrypoint.sh"]

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+# Alias for WP-cli to include arguments that we want to use everywhere
+shopt -s expand_aliases
+alias wp="wp --path=$DOCUMENT_ROOT --allow-root"
+
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 	: "${WORDPRESS_DB_HOST:=mysql}"
 	# if we're linked to MySQL and thus have credentials already, let's use them
@@ -45,8 +49,25 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		fi
 	fi
 
-	# TODO handle WordPress upgrades magically in the same way, but only if wp-includes/version.php's $wp_version is less than /usr/src/wordpress/wp-includes/version.php's $wp_version
+	# handle WordPress upgrades magically with wp-cli
+	# can be set through env on runtime or arg on build time
+	# defaults to WP_VERSION=latest
+	if [ wp core is-installed ]; then
+		wp core update --version=$WP_VERSION
 
+		# update all plugins
+		wp plugin update --all
+
+		# install plugins provided in the WORDPRESS_PLUGINS env variable
+		if [ "$WORDPRESS_PLUGINS" ]; then
+			for $plugin in $WORDPRESS_PLUGINS; do 
+				if ! $(wp plugin is-installed ${plugin}); then
+					wp plugin install $plugin
+				fi
+			done 
+		fi
+	fi
+	
 	# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
 	# https://github.com/docker-library/wordpress/issues/116
 	# https://github.com/WordPress/WordPress/commit/1acedc542fba2482bab88ec70d4bea4b997a92e4


### PR DESCRIPTION
This pull requests contains changes for the use of wp-cli to provide some useful functionalities for wp setup through configuration management with docker-compose.

Updates to wp core and plugins are included.

**Current new features (on build time):**
- provide a wp_version to be included within the image; persists through ENV WP_BUILD_VERSION
- provide a wp_locale to set the language for the image source files
- provide a list of php extensions to be embedded into the image (needed for plugins)

**Current new features (on runtime):**
- update to the image version or provide a WORDPRESS_VERSION
- update all plugins if wordpress is installed on container startup
- provide a list of plugins through WP_PLUGINS to be installed on next container start

**Possible features for the future**
- direct install wordpress through env config (useful for automated setup with even plugins through config)
- provide any possible interface to the wp-cli you can think of
- add a SCRIPTS_DIR volume to map custom scripts into the image on startup
