### PR TITLE
Add explicit "cli" variants for wp-cli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,15 @@ env:
   - VARIANT=php5.6/apache
   - VARIANT=php5.6/fpm
   - VARIANT=php5.6/fpm-alpine
+  - VARIANT=php5.6/cli
   - VARIANT=php7.0/apache
   - VARIANT=php7.0/fpm
   - VARIANT=php7.0/fpm-alpine
+  - VARIANT=php7.0/cli
   - VARIANT=php7.1/apache
   - VARIANT=php7.1/fpm
   - VARIANT=php7.1/fpm-alpine
+  - VARIANT=php7.1/cli
 
 install:
   - git clone https://github.com/docker-library/official-images.git ~/official-images

--- a/Dockerfile-cli.template
+++ b/Dockerfile-cli.template
@@ -1,0 +1,80 @@
+FROM php:%%PHP_VERSION%%-alpine
+
+# install the PHP extensions we need
+RUN set -ex; \
+	\
+	apk add --no-cache --virtual .build-deps \
+		libjpeg-turbo-dev \
+		libpng-dev \
+	; \
+	\
+	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	docker-php-ext-install gd mysqli opcache; \
+	\
+	runDeps="$( \
+		scanelf --needed --nobanner --recursive \
+			/usr/local/lib/php/extensions \
+			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+			| sort -u \
+			| xargs -r apk info --installed \
+			| sort -u \
+	)"; \
+	apk add --virtual .wordpress-phpexts-rundeps $runDeps; \
+	apk del .build-deps
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+		echo 'opcache.fast_shutdown=1'; \
+		echo 'opcache.enable_cli=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+# install wp-cli dependencies
+RUN apk add --no-cache \
+		less \
+		mysql-client
+
+RUN set -ex; \
+	mkdir -p /var/www/html; \
+	chown -R www-data:www-data /var/www/html
+WORKDIR /var/www/html
+VOLUME /var/www/html
+
+# pub   2048R/2F6B6B7F 2016-01-07
+#       Key fingerprint = 3B91 9162 5F3B 1F1B F5DD  3B47 673A 0204 2F6B 6B7F
+# uid                  Daniel Bachhuber <daniel@handbuilt.co>
+# sub   2048R/45F9CDE2 2016-01-07
+ENV WORDPRESS_CLI_GPG_KEY 3B9191625F3B1F1BF5DD3B47673A02042F6B6B7F
+
+ENV WORDPRESS_CLI_VERSION %%WORDPRESS_CLI_VERSION%%
+ENV WORDPRESS_CLI_SHA512 %%WORDPRESS_CLI_SHA512%%
+
+RUN set -ex; \
+	\
+	apk add --no-cache --virtual .fetch-deps \
+		gnupg \
+	; \
+	\
+	curl -o /usr/local/bin/wp.gpg -fSL "https://github.com/wp-cli/wp-cli/releases/download/v${WORDPRESS_CLI_VERSION}/wp-cli-${WORDPRESS_CLI_VERSION}.phar.gpg"; \
+	\
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$WORDPRESS_CLI_GPG_KEY"; \
+	gpg --batch --decrypt --output /usr/local/bin/wp /usr/local/bin/wp.gpg; \
+	rm -r "$GNUPGHOME" /usr/local/bin/wp.gpg; \
+	\
+	echo "$WORDPRESS_CLI_SHA512 */usr/local/bin/wp" | sha512sum -c -; \
+	chmod +x /usr/local/bin/wp; \
+	\
+	apk del .fetch-deps; \
+	\
+	wp --allow-root --version
+
+COPY docker-entrypoint.sh /usr/local/bin/
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+USER www-data
+CMD ["wp", "shell"]

--- a/cli-entrypoint.sh
+++ b/cli-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -euo pipefail
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- wp "$@"
+fi
+
+# if our command is a valid wp-cli subcommand, let's invoke it through wp-cli instead
+# (this allows for "docker run wordpress:cli help", etc)
+if wp --path=/dev/null help "$1" > /dev/null 2>&1; then
+	set -- wp "$@"
+fi
+
+exec "$@"

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -134,8 +134,9 @@ for phpVersion in "${phpVersions[@]}"; do
 	variantAliases=( "${versionAliases[@]/#/$variant-}" )
 	variantAliases=( "${variantAliases[@]//-latest/}" )
 
-	phpVersionVariantAliases=( "${versionAliases[@]/#/$phpVersion-$variant-}" )
+	phpVersionVariantAliases=( "${versionAliases[@]/#/$variant-}" )
 	phpVersionVariantAliases=( "${phpVersionVariantAliases[@]//-latest/}" )
+	phpVersionVariantAliases=( "${phpVersionVariantAliases[@]/%/-$phpVersion}" )
 
 	fullAliases=()
 

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -104,3 +104,53 @@ for phpVersion in "${phpVersions[@]}"; do
 		EOE
 	done
 done
+
+echo
+echo '# Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)'
+
+for phpVersion in "${phpVersions[@]}"; do
+	variant='cli'
+
+	dir="$phpVersion/$variant"
+	[ -f "$dir/Dockerfile" ] || continue
+
+	commit="$(dirCommit "$dir")"
+
+	fullVersion="$(git show "$commit":"$dir/Dockerfile" | awk '$1 == "ENV" && $2 == "WORDPRESS_CLI_VERSION" { print $3; exit }')"
+
+	versionAliases=()
+	while [ "${fullVersion%[.-]*}" != "$fullVersion" ]; do
+		versionAliases+=( $fullVersion )
+		fullVersion="${fullVersion%[.-]*}"
+	done
+	versionAliases+=(
+		$fullVersion
+		latest
+	)
+
+	phpVersionAliases=( "${versionAliases[@]/#/$phpVersion-}" )
+	phpVersionAliases=( "${phpVersionAliases[@]//-latest/}" )
+
+	variantAliases=( "${versionAliases[@]/#/$variant-}" )
+	variantAliases=( "${variantAliases[@]//-latest/}" )
+
+	phpVersionVariantAliases=( "${versionAliases[@]/#/$phpVersion-$variant-}" )
+	phpVersionVariantAliases=( "${phpVersionVariantAliases[@]//-latest/}" )
+
+	fullAliases=()
+
+	if [ "$phpVersion" = "$defaultPhpVersion" ]; then
+		fullAliases+=( "${variantAliases[@]}" )
+	fi
+
+	fullAliases+=(
+		"${phpVersionVariantAliases[@]}"
+	)
+
+	echo
+	cat <<-EOE
+		Tags: $(join ', ' "${fullAliases[@]}")
+		GitCommit: $commit
+		Directory: $dir
+	EOE
+done

--- a/php5.6/cli/Dockerfile
+++ b/php5.6/cli/Dockerfile
@@ -1,0 +1,80 @@
+FROM php:5.6-alpine
+
+# install the PHP extensions we need
+RUN set -ex; \
+	\
+	apk add --no-cache --virtual .build-deps \
+		libjpeg-turbo-dev \
+		libpng-dev \
+	; \
+	\
+	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	docker-php-ext-install gd mysqli opcache; \
+	\
+	runDeps="$( \
+		scanelf --needed --nobanner --recursive \
+			/usr/local/lib/php/extensions \
+			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+			| sort -u \
+			| xargs -r apk info --installed \
+			| sort -u \
+	)"; \
+	apk add --virtual .wordpress-phpexts-rundeps $runDeps; \
+	apk del .build-deps
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+		echo 'opcache.fast_shutdown=1'; \
+		echo 'opcache.enable_cli=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+# install wp-cli dependencies
+RUN apk add --no-cache \
+		less \
+		mysql-client
+
+RUN set -ex; \
+	mkdir -p /var/www/html; \
+	chown -R www-data:www-data /var/www/html
+WORKDIR /var/www/html
+VOLUME /var/www/html
+
+# pub   2048R/2F6B6B7F 2016-01-07
+#       Key fingerprint = 3B91 9162 5F3B 1F1B F5DD  3B47 673A 0204 2F6B 6B7F
+# uid                  Daniel Bachhuber <daniel@handbuilt.co>
+# sub   2048R/45F9CDE2 2016-01-07
+ENV WORDPRESS_CLI_GPG_KEY 3B9191625F3B1F1BF5DD3B47673A02042F6B6B7F
+
+ENV WORDPRESS_CLI_VERSION 1.1.0
+ENV WORDPRESS_CLI_SHA512 1fb4a3800441fc5188dac73efc6ca865076772ef698189ded379c53947d1fec30311e84eb4371455d415ef2cbb33d7593240fdf7b7f206277a12cfa8596d4b51
+
+RUN set -ex; \
+	\
+	apk add --no-cache --virtual .fetch-deps \
+		gnupg \
+	; \
+	\
+	curl -o /usr/local/bin/wp.gpg -fSL "https://github.com/wp-cli/wp-cli/releases/download/v${WORDPRESS_CLI_VERSION}/wp-cli-${WORDPRESS_CLI_VERSION}.phar.gpg"; \
+	\
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$WORDPRESS_CLI_GPG_KEY"; \
+	gpg --batch --decrypt --output /usr/local/bin/wp /usr/local/bin/wp.gpg; \
+	rm -r "$GNUPGHOME" /usr/local/bin/wp.gpg; \
+	\
+	echo "$WORDPRESS_CLI_SHA512 */usr/local/bin/wp" | sha512sum -c -; \
+	chmod +x /usr/local/bin/wp; \
+	\
+	apk del .fetch-deps; \
+	\
+	wp --allow-root --version
+
+COPY docker-entrypoint.sh /usr/local/bin/
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+USER www-data
+CMD ["wp", "shell"]

--- a/php5.6/cli/docker-entrypoint.sh
+++ b/php5.6/cli/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -euo pipefail
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- wp "$@"
+fi
+
+# if our command is a valid wp-cli subcommand, let's invoke it through wp-cli instead
+# (this allows for "docker run wordpress:cli help", etc)
+if wp --path=/dev/null help "$1" > /dev/null 2>&1; then
+	set -- wp "$@"
+fi
+
+exec "$@"

--- a/php7.0/cli/Dockerfile
+++ b/php7.0/cli/Dockerfile
@@ -1,0 +1,80 @@
+FROM php:7.0-alpine
+
+# install the PHP extensions we need
+RUN set -ex; \
+	\
+	apk add --no-cache --virtual .build-deps \
+		libjpeg-turbo-dev \
+		libpng-dev \
+	; \
+	\
+	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	docker-php-ext-install gd mysqli opcache; \
+	\
+	runDeps="$( \
+		scanelf --needed --nobanner --recursive \
+			/usr/local/lib/php/extensions \
+			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+			| sort -u \
+			| xargs -r apk info --installed \
+			| sort -u \
+	)"; \
+	apk add --virtual .wordpress-phpexts-rundeps $runDeps; \
+	apk del .build-deps
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+		echo 'opcache.fast_shutdown=1'; \
+		echo 'opcache.enable_cli=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+# install wp-cli dependencies
+RUN apk add --no-cache \
+		less \
+		mysql-client
+
+RUN set -ex; \
+	mkdir -p /var/www/html; \
+	chown -R www-data:www-data /var/www/html
+WORKDIR /var/www/html
+VOLUME /var/www/html
+
+# pub   2048R/2F6B6B7F 2016-01-07
+#       Key fingerprint = 3B91 9162 5F3B 1F1B F5DD  3B47 673A 0204 2F6B 6B7F
+# uid                  Daniel Bachhuber <daniel@handbuilt.co>
+# sub   2048R/45F9CDE2 2016-01-07
+ENV WORDPRESS_CLI_GPG_KEY 3B9191625F3B1F1BF5DD3B47673A02042F6B6B7F
+
+ENV WORDPRESS_CLI_VERSION 1.1.0
+ENV WORDPRESS_CLI_SHA512 1fb4a3800441fc5188dac73efc6ca865076772ef698189ded379c53947d1fec30311e84eb4371455d415ef2cbb33d7593240fdf7b7f206277a12cfa8596d4b51
+
+RUN set -ex; \
+	\
+	apk add --no-cache --virtual .fetch-deps \
+		gnupg \
+	; \
+	\
+	curl -o /usr/local/bin/wp.gpg -fSL "https://github.com/wp-cli/wp-cli/releases/download/v${WORDPRESS_CLI_VERSION}/wp-cli-${WORDPRESS_CLI_VERSION}.phar.gpg"; \
+	\
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$WORDPRESS_CLI_GPG_KEY"; \
+	gpg --batch --decrypt --output /usr/local/bin/wp /usr/local/bin/wp.gpg; \
+	rm -r "$GNUPGHOME" /usr/local/bin/wp.gpg; \
+	\
+	echo "$WORDPRESS_CLI_SHA512 */usr/local/bin/wp" | sha512sum -c -; \
+	chmod +x /usr/local/bin/wp; \
+	\
+	apk del .fetch-deps; \
+	\
+	wp --allow-root --version
+
+COPY docker-entrypoint.sh /usr/local/bin/
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+USER www-data
+CMD ["wp", "shell"]

--- a/php7.0/cli/docker-entrypoint.sh
+++ b/php7.0/cli/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -euo pipefail
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- wp "$@"
+fi
+
+# if our command is a valid wp-cli subcommand, let's invoke it through wp-cli instead
+# (this allows for "docker run wordpress:cli help", etc)
+if wp --path=/dev/null help "$1" > /dev/null 2>&1; then
+	set -- wp "$@"
+fi
+
+exec "$@"

--- a/php7.1/cli/Dockerfile
+++ b/php7.1/cli/Dockerfile
@@ -1,0 +1,80 @@
+FROM php:7.1-alpine
+
+# install the PHP extensions we need
+RUN set -ex; \
+	\
+	apk add --no-cache --virtual .build-deps \
+		libjpeg-turbo-dev \
+		libpng-dev \
+	; \
+	\
+	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	docker-php-ext-install gd mysqli opcache; \
+	\
+	runDeps="$( \
+		scanelf --needed --nobanner --recursive \
+			/usr/local/lib/php/extensions \
+			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+			| sort -u \
+			| xargs -r apk info --installed \
+			| sort -u \
+	)"; \
+	apk add --virtual .wordpress-phpexts-rundeps $runDeps; \
+	apk del .build-deps
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+		echo 'opcache.fast_shutdown=1'; \
+		echo 'opcache.enable_cli=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+# install wp-cli dependencies
+RUN apk add --no-cache \
+		less \
+		mysql-client
+
+RUN set -ex; \
+	mkdir -p /var/www/html; \
+	chown -R www-data:www-data /var/www/html
+WORKDIR /var/www/html
+VOLUME /var/www/html
+
+# pub   2048R/2F6B6B7F 2016-01-07
+#       Key fingerprint = 3B91 9162 5F3B 1F1B F5DD  3B47 673A 0204 2F6B 6B7F
+# uid                  Daniel Bachhuber <daniel@handbuilt.co>
+# sub   2048R/45F9CDE2 2016-01-07
+ENV WORDPRESS_CLI_GPG_KEY 3B9191625F3B1F1BF5DD3B47673A02042F6B6B7F
+
+ENV WORDPRESS_CLI_VERSION 1.1.0
+ENV WORDPRESS_CLI_SHA512 1fb4a3800441fc5188dac73efc6ca865076772ef698189ded379c53947d1fec30311e84eb4371455d415ef2cbb33d7593240fdf7b7f206277a12cfa8596d4b51
+
+RUN set -ex; \
+	\
+	apk add --no-cache --virtual .fetch-deps \
+		gnupg \
+	; \
+	\
+	curl -o /usr/local/bin/wp.gpg -fSL "https://github.com/wp-cli/wp-cli/releases/download/v${WORDPRESS_CLI_VERSION}/wp-cli-${WORDPRESS_CLI_VERSION}.phar.gpg"; \
+	\
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$WORDPRESS_CLI_GPG_KEY"; \
+	gpg --batch --decrypt --output /usr/local/bin/wp /usr/local/bin/wp.gpg; \
+	rm -r "$GNUPGHOME" /usr/local/bin/wp.gpg; \
+	\
+	echo "$WORDPRESS_CLI_SHA512 */usr/local/bin/wp" | sha512sum -c -; \
+	chmod +x /usr/local/bin/wp; \
+	\
+	apk del .fetch-deps; \
+	\
+	wp --allow-root --version
+
+COPY docker-entrypoint.sh /usr/local/bin/
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+USER www-data
+CMD ["wp", "shell"]

--- a/php7.1/cli/docker-entrypoint.sh
+++ b/php7.1/cli/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -euo pipefail
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- wp "$@"
+fi
+
+# if our command is a valid wp-cli subcommand, let's invoke it through wp-cli instead
+# (this allows for "docker run wordpress:cli help", etc)
+if wp --path=/dev/null help "$1" > /dev/null 2>&1; then
+	set -- wp "$@"
+fi
+
+exec "$@"

--- a/update.sh
+++ b/update.sh
@@ -12,20 +12,30 @@ phpVersions=( "${phpVersions[@]%/}" )
 current="$(curl -fsSL 'http://api.wordpress.org/core/version-check/1.7/' | jq -r '.offers[0].current')"
 sha1="$(curl -fsSL "https://wordpress.org/wordpress-$current.tar.gz.sha1")"
 
+cliVersion="$(
+	git ls-remote --tags 'https://github.com/wp-cli/wp-cli.git' \
+		| sed -r 's!^[^\t]+\trefs/tags/v([^^]+).*!\1!g' \
+		| tail -1
+)"
+cliSha512="$(curl -fsSL "https://github.com/wp-cli/wp-cli/releases/download/v${cliVersion}/wp-cli-${cliVersion}.phar.sha512")"
+
 declare -A variantExtras=(
 	[apache]='\nRUN a2enmod rewrite expires\n'
 	[fpm]=''
 	[fpm-alpine]=''
+	[cli]='' # unused
 )
 declare -A variantCmds=(
 	[apache]='apache2-foreground'
 	[fpm]='php-fpm'
 	[fpm-alpine]='php-fpm'
+	[cli]='' # unused
 )
 declare -A variantBases=(
 	[apache]='debian'
 	[fpm]='debian'
 	[fpm-alpine]='alpine'
+	[cli]='cli'
 )
 
 travisEnv=
@@ -33,13 +43,18 @@ for phpVersion in "${phpVersions[@]}"; do
 	phpVersionDir="$phpVersion"
 	phpVersion="${phpVersion#php}"
 
-	for variant in apache fpm fpm-alpine; do
+	for variant in apache fpm fpm-alpine cli; do
 		dir="$phpVersionDir/$variant"
 		mkdir -p "$dir"
 
 		extras="${variantExtras[$variant]}"
 		cmd="${variantCmds[$variant]}"
 		base="${variantBases[$variant]}"
+
+		entrypoint='docker-entrypoint.sh'
+		if [ "$variant" = 'cli' ]; then
+			entrypoint='cli-entrypoint.sh'
+		fi
 
 		(
 			set -x
@@ -49,11 +64,13 @@ for phpVersion in "${phpVersions[@]}"; do
 				-e 's!%%WORDPRESS_SHA1%%!'"$sha1"'!g' \
 				-e 's!%%PHP_VERSION%%!'"$phpVersion"'!g' \
 				-e 's!%%VARIANT%%!'"$variant"'!g' \
+				-e 's!%%WORDPRESS_CLI_VERSION%%!'"$cliVersion"'!g' \
+				-e 's!%%WORDPRESS_CLI_SHA512%%!'"$cliSha512"'!g' \
 				-e 's!%%VARIANT_EXTRAS%%!'"$extras"'!g' \
 				-e 's!%%CMD%%!'"$cmd"'!g' \
 				"Dockerfile-${base}.template" > "$dir/Dockerfile"
 
-			cp docker-entrypoint.sh "$dir/docker-entrypoint.sh"
+			cp -a "$entrypoint" "$dir/docker-entrypoint.sh"
 		)
 
 		travisEnv+='\n  - VARIANT='"$dir"


### PR DESCRIPTION
See also:

- https://make.wordpress.org/core/2016/12/28/supporting-the-future-of-wp-cli/
- https://make.wordpress.org/cli/2017/01/03/lets-do-this/

The expected usage for these images is something like the following:

    docker run -it --rm \
        --volumes-from some-wordpress \
        --network container:some-wordpress \
        wordpress:cli user list

Closes #176