### PR TITLE
Adjust "wp-config.php" behavior to be skipped if configuration is not provided

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -24,31 +24,14 @@ file_env() {
 }
 
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
-	file_env 'WORDPRESS_DB_HOST' 'mysql'
-	# if we're linked to MySQL and thus have credentials already, let's use them
-	file_env 'WORDPRESS_DB_USER' "${MYSQL_ENV_MYSQL_USER:-root}"
-	if [ "$WORDPRESS_DB_USER" = 'root' ]; then
-		file_env 'WORDPRESS_DB_PASSWORD' "${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}"
-	else
-		file_env 'WORDPRESS_DB_PASSWORD' "${MYSQL_ENV_MYSQL_PASSWORD:-}"
-	fi
-	file_env 'WORDPRESS_DB_NAME' "${MYSQL_ENV_MYSQL_DATABASE:-wordpress}"
-	if [ -z "$WORDPRESS_DB_PASSWORD" ]; then
-		echo >&2 'error: missing required WORDPRESS_DB_PASSWORD environment variable'
-		echo >&2 '  Did you forget to -e WORDPRESS_DB_PASSWORD=... ?'
-		echo >&2
-		echo >&2 '  (Also of interest might be WORDPRESS_DB_USER and WORDPRESS_DB_NAME.)'
-		exit 1
-	fi
-
 	if ! [ -e index.php -a -e wp-includes/version.php ]; then
-		echo >&2 "WordPress not found in $(pwd) - copying now..."
+		echo >&2 "WordPress not found in $PWD - copying now..."
 		if [ "$(ls -A)" ]; then
-			echo >&2 "WARNING: $(pwd) is not empty - press Ctrl+C now if this is an error!"
+			echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
 			( set -x; ls -A; sleep 10 )
 		fi
 		tar cf - --one-file-system -C /usr/src/wordpress . | tar xf -
-		echo >&2 "Complete! WordPress has been successfully copied to $(pwd)"
+		echo >&2 "Complete! WordPress has been successfully copied to $PWD"
 		if [ ! -e .htaccess ]; then
 			# NOTE: The "Indexes" option is disabled in the php:apache base image
 			cat > .htaccess <<-'EOF'
@@ -69,54 +52,9 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
 	# TODO handle WordPress upgrades magically in the same way, but only if wp-includes/version.php's $wp_version is less than /usr/src/wordpress/wp-includes/version.php's $wp_version
 
-	# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
-	# https://github.com/docker-library/wordpress/issues/116
-	# https://github.com/WordPress/WordPress/commit/1acedc542fba2482bab88ec70d4bea4b997a92e4
-	sed -ri -e 's/\r$//' wp-config*
-
-	if [ ! -e wp-config.php ]; then
-		awk '/^\/\*.*stop editing.*\*\/$/ && c == 0 { c = 1; system("cat") } { print }' wp-config-sample.php > wp-config.php <<'EOPHP'
-// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
-// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
-if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
-	$_SERVER['HTTPS'] = 'on';
-}
-
-EOPHP
-		chown www-data:www-data wp-config.php
-	fi
-
-	# see http://stackoverflow.com/a/2705678/433558
-	sed_escape_lhs() {
-		echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
-	}
-	sed_escape_rhs() {
-		echo "$@" | sed -e 's/[\/&]/\\&/g'
-	}
-	php_escape() {
-		php -r 'var_export(('$2') $argv[1]);' -- "$1"
-	}
-	set_config() {
-		key="$1"
-		value="$2"
-		var_type="${3:-string}"
-		start="(['\"])$(sed_escape_lhs "$key")\2\s*,"
-		end="\);"
-		if [ "${key:0:1}" = '$' ]; then
-			start="^(\s*)$(sed_escape_lhs "$key")\s*="
-			end=";"
-		fi
-		sed -ri -e "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
-	}
-
-	set_config 'DB_HOST' "$WORDPRESS_DB_HOST"
-	set_config 'DB_USER' "$WORDPRESS_DB_USER"
-	set_config 'DB_PASSWORD' "$WORDPRESS_DB_PASSWORD"
-	set_config 'DB_NAME' "$WORDPRESS_DB_NAME"
-
 	# allow any of these "Authentication Unique Keys and Salts." to be specified via
 	# environment variables with a "WORDPRESS_" prefix (ie, "WORDPRESS_AUTH_KEY")
-	UNIQUES=(
+	uniqueEnvs=(
 		AUTH_KEY
 		SECURE_AUTH_KEY
 		LOGGED_IN_KEY
@@ -126,31 +64,110 @@ EOPHP
 		LOGGED_IN_SALT
 		NONCE_SALT
 	)
-	for unique in "${UNIQUES[@]}"; do
-		uniqVar="WORDPRESS_$unique"
-		file_env "$uniqVar"
-		if [ "${!uniqVar}" ]; then
-			set_config "$unique" "${!uniqVar}"
-		else
-			# if not specified, let's generate a random value
-			current_set="$(sed -rn -e "s/define\((([\'\"])$unique\2\s*,\s*)(['\"])(.*)\3\);/\4/p" wp-config.php)"
-			if [ "$current_set" = 'put your unique phrase here' ]; then
-				set_config "$unique" "$(head -c1m /dev/urandom | sha1sum | cut -d' ' -f1)"
-			fi
+	envs=(
+		WORDPRESS_DB_HOST
+		WORDPRESS_DB_USER
+		WORDPRESS_DB_PASSWORD
+		WORDPRESS_DB_NAME
+		"${uniqueEnvs[@]/#/WORDPRESS_}"
+		WORDPRESS_TABLE_PREFIX
+		WORDPRESS_DEBUG
+	)
+	haveConfig=
+	for e in "${envs[@]}"; do
+		file_env "$e"
+		if [ -z "$haveConfig" ] && [ -n "${!e}" ]; then
+			haveConfig=1
 		fi
 	done
 
-	file_env 'WORDPRESS_TABLE_PREFIX'
-	if [ "$WORDPRESS_TABLE_PREFIX" ]; then
-		set_config '$table_prefix' "$WORDPRESS_TABLE_PREFIX"
+	# linking backwards-compatibility
+	if [ -n "${!MYSQL_ENV_MYSQL_*}" ]; then
+		haveConfig=1
+		# host defaults to "mysql" below if unspecified
+		: "${WORDPRESS_DB_USER:=${MYSQL_ENV_MYSQL_USER:-root}}"
+		if [ "$WORDPRESS_DB_USER" = 'root' ]; then
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}}"
+		else
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_PASSWORD:-}}"
+		fi
+		: "${WORDPRESS_DB_NAME:=${MYSQL_ENV_MYSQL_DATABASE:-}}"
 	fi
 
-	file_env 'WORDPRESS_DEBUG'
-	if [ "$WORDPRESS_DEBUG" ]; then
-		set_config 'WP_DEBUG' 1 boolean
-	fi
+	# only touch "wp-config.php" if we have environment-supplied configuration values
+	if [ "$haveConfig" ]; then
+		: "${WORDPRESS_DB_HOST:=mysql}"
+		: "${WORDPRESS_DB_USER:=root}"
+		: "${WORDPRESS_DB_PASSWORD:=}"
+		: "${WORDPRESS_DB_NAME:=wordpress}"
 
-	TERM=dumb php -- "$WORDPRESS_DB_HOST" "$WORDPRESS_DB_USER" "$WORDPRESS_DB_PASSWORD" "$WORDPRESS_DB_NAME" <<'EOPHP'
+		# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
+		# https://github.com/docker-library/wordpress/issues/116
+		# https://github.com/WordPress/WordPress/commit/1acedc542fba2482bab88ec70d4bea4b997a92e4
+		sed -ri -e 's/\r$//' wp-config*
+
+		if [ ! -e wp-config.php ]; then
+			awk '/^\/\*.*stop editing.*\*\/$/ && c == 0 { c = 1; system("cat") } { print }' wp-config-sample.php > wp-config.php <<'EOPHP'
+// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
+// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+	$_SERVER['HTTPS'] = 'on';
+}
+
+EOPHP
+			chown www-data:www-data wp-config.php
+		fi
+
+		# see http://stackoverflow.com/a/2705678/433558
+		sed_escape_lhs() {
+			echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
+		}
+		sed_escape_rhs() {
+			echo "$@" | sed -e 's/[\/&]/\\&/g'
+		}
+		php_escape() {
+			php -r 'var_export(('$2') $argv[1]);' -- "$1"
+		}
+		set_config() {
+			key="$1"
+			value="$2"
+			var_type="${3:-string}"
+			start="(['\"])$(sed_escape_lhs "$key")\2\s*,"
+			end="\);"
+			if [ "${key:0:1}" = '$' ]; then
+				start="^(\s*)$(sed_escape_lhs "$key")\s*="
+				end=";"
+			fi
+			sed -ri -e "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
+		}
+
+		set_config 'DB_HOST' "$WORDPRESS_DB_HOST"
+		set_config 'DB_USER' "$WORDPRESS_DB_USER"
+		set_config 'DB_PASSWORD' "$WORDPRESS_DB_PASSWORD"
+		set_config 'DB_NAME' "$WORDPRESS_DB_NAME"
+
+		for unique in "${uniqueEnvs[@]}"; do
+			uniqVar="WORDPRESS_$unique"
+			if [ -n "${!uniqVar}" ]; then
+				set_config "$unique" "${!uniqVar}"
+			else
+				# if not specified, let's generate a random value
+				currentVal="$(sed -rn -e "s/define\((([\'\"])$unique\2\s*,\s*)(['\"])(.*)\3\);/\4/p" wp-config.php)"
+				if [ "$currentVal" = 'put your unique phrase here' ]; then
+					set_config "$unique" "$(head -c1m /dev/urandom | sha1sum | cut -d' ' -f1)"
+				fi
+			fi
+		done
+
+		if [ "$WORDPRESS_TABLE_PREFIX" ]; then
+			set_config '$table_prefix' "$WORDPRESS_TABLE_PREFIX"
+		fi
+
+		if [ "$WORDPRESS_DEBUG" ]; then
+			set_config 'WP_DEBUG' 1 boolean
+		fi
+
+		TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 
@@ -160,16 +177,19 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = explode(':', $argv[1], 2);
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 
 $maxTries = 10;
 do {
-	$mysql = new mysqli($host, $argv[2], $argv[3], '', $port, $socket);
+	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);
 	if ($mysql->connect_error) {
 		fwrite($stderr, "\n" . 'MySQL Connection Error: (' . $mysql->connect_errno . ') ' . $mysql->connect_error . "\n");
 		--$maxTries;
@@ -180,7 +200,7 @@ do {
 	}
 } while ($mysql->connect_error);
 
-if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_string($argv[4]) . '`')) {
+if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_string($dbName) . '`')) {
 	fwrite($stderr, "\n" . 'MySQL "CREATE DATABASE" Error: ' . $mysql->error . "\n");
 	$mysql->close();
 	exit(1);
@@ -188,6 +208,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 
 $mysql->close();
 EOPHP
+	fi
+
+	# now that we're definitely done writing configuration, let's clear out the relevant envrionment variables (so that stray "phpinfo()" calls don't leak secrets from our code)
+	for e in "${envs[@]}"; do
+		unset "$e"
+	done
 fi
 
 exec "$@"

--- a/php5.6/apache/docker-entrypoint.sh
+++ b/php5.6/apache/docker-entrypoint.sh
@@ -24,31 +24,14 @@ file_env() {
 }
 
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
-	file_env 'WORDPRESS_DB_HOST' 'mysql'
-	# if we're linked to MySQL and thus have credentials already, let's use them
-	file_env 'WORDPRESS_DB_USER' "${MYSQL_ENV_MYSQL_USER:-root}"
-	if [ "$WORDPRESS_DB_USER" = 'root' ]; then
-		file_env 'WORDPRESS_DB_PASSWORD' "${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}"
-	else
-		file_env 'WORDPRESS_DB_PASSWORD' "${MYSQL_ENV_MYSQL_PASSWORD:-}"
-	fi
-	file_env 'WORDPRESS_DB_NAME' "${MYSQL_ENV_MYSQL_DATABASE:-wordpress}"
-	if [ -z "$WORDPRESS_DB_PASSWORD" ]; then
-		echo >&2 'error: missing required WORDPRESS_DB_PASSWORD environment variable'
-		echo >&2 '  Did you forget to -e WORDPRESS_DB_PASSWORD=... ?'
-		echo >&2
-		echo >&2 '  (Also of interest might be WORDPRESS_DB_USER and WORDPRESS_DB_NAME.)'
-		exit 1
-	fi
-
 	if ! [ -e index.php -a -e wp-includes/version.php ]; then
-		echo >&2 "WordPress not found in $(pwd) - copying now..."
+		echo >&2 "WordPress not found in $PWD - copying now..."
 		if [ "$(ls -A)" ]; then
-			echo >&2 "WARNING: $(pwd) is not empty - press Ctrl+C now if this is an error!"
+			echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
 			( set -x; ls -A; sleep 10 )
 		fi
 		tar cf - --one-file-system -C /usr/src/wordpress . | tar xf -
-		echo >&2 "Complete! WordPress has been successfully copied to $(pwd)"
+		echo >&2 "Complete! WordPress has been successfully copied to $PWD"
 		if [ ! -e .htaccess ]; then
 			# NOTE: The "Indexes" option is disabled in the php:apache base image
 			cat > .htaccess <<-'EOF'
@@ -69,54 +52,9 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
 	# TODO handle WordPress upgrades magically in the same way, but only if wp-includes/version.php's $wp_version is less than /usr/src/wordpress/wp-includes/version.php's $wp_version
 
-	# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
-	# https://github.com/docker-library/wordpress/issues/116
-	# https://github.com/WordPress/WordPress/commit/1acedc542fba2482bab88ec70d4bea4b997a92e4
-	sed -ri -e 's/\r$//' wp-config*
-
-	if [ ! -e wp-config.php ]; then
-		awk '/^\/\*.*stop editing.*\*\/$/ && c == 0 { c = 1; system("cat") } { print }' wp-config-sample.php > wp-config.php <<'EOPHP'
-// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
-// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
-if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
-	$_SERVER['HTTPS'] = 'on';
-}
-
-EOPHP
-		chown www-data:www-data wp-config.php
-	fi
-
-	# see http://stackoverflow.com/a/2705678/433558
-	sed_escape_lhs() {
-		echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
-	}
-	sed_escape_rhs() {
-		echo "$@" | sed -e 's/[\/&]/\\&/g'
-	}
-	php_escape() {
-		php -r 'var_export(('$2') $argv[1]);' -- "$1"
-	}
-	set_config() {
-		key="$1"
-		value="$2"
-		var_type="${3:-string}"
-		start="(['\"])$(sed_escape_lhs "$key")\2\s*,"
-		end="\);"
-		if [ "${key:0:1}" = '$' ]; then
-			start="^(\s*)$(sed_escape_lhs "$key")\s*="
-			end=";"
-		fi
-		sed -ri -e "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
-	}
-
-	set_config 'DB_HOST' "$WORDPRESS_DB_HOST"
-	set_config 'DB_USER' "$WORDPRESS_DB_USER"
-	set_config 'DB_PASSWORD' "$WORDPRESS_DB_PASSWORD"
-	set_config 'DB_NAME' "$WORDPRESS_DB_NAME"
-
 	# allow any of these "Authentication Unique Keys and Salts." to be specified via
 	# environment variables with a "WORDPRESS_" prefix (ie, "WORDPRESS_AUTH_KEY")
-	UNIQUES=(
+	uniqueEnvs=(
 		AUTH_KEY
 		SECURE_AUTH_KEY
 		LOGGED_IN_KEY
@@ -126,31 +64,110 @@ EOPHP
 		LOGGED_IN_SALT
 		NONCE_SALT
 	)
-	for unique in "${UNIQUES[@]}"; do
-		uniqVar="WORDPRESS_$unique"
-		file_env "$uniqVar"
-		if [ "${!uniqVar}" ]; then
-			set_config "$unique" "${!uniqVar}"
-		else
-			# if not specified, let's generate a random value
-			current_set="$(sed -rn -e "s/define\((([\'\"])$unique\2\s*,\s*)(['\"])(.*)\3\);/\4/p" wp-config.php)"
-			if [ "$current_set" = 'put your unique phrase here' ]; then
-				set_config "$unique" "$(head -c1m /dev/urandom | sha1sum | cut -d' ' -f1)"
-			fi
+	envs=(
+		WORDPRESS_DB_HOST
+		WORDPRESS_DB_USER
+		WORDPRESS_DB_PASSWORD
+		WORDPRESS_DB_NAME
+		"${uniqueEnvs[@]/#/WORDPRESS_}"
+		WORDPRESS_TABLE_PREFIX
+		WORDPRESS_DEBUG
+	)
+	haveConfig=
+	for e in "${envs[@]}"; do
+		file_env "$e"
+		if [ -z "$haveConfig" ] && [ -n "${!e}" ]; then
+			haveConfig=1
 		fi
 	done
 
-	file_env 'WORDPRESS_TABLE_PREFIX'
-	if [ "$WORDPRESS_TABLE_PREFIX" ]; then
-		set_config '$table_prefix' "$WORDPRESS_TABLE_PREFIX"
+	# linking backwards-compatibility
+	if [ -n "${!MYSQL_ENV_MYSQL_*}" ]; then
+		haveConfig=1
+		# host defaults to "mysql" below if unspecified
+		: "${WORDPRESS_DB_USER:=${MYSQL_ENV_MYSQL_USER:-root}}"
+		if [ "$WORDPRESS_DB_USER" = 'root' ]; then
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}}"
+		else
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_PASSWORD:-}}"
+		fi
+		: "${WORDPRESS_DB_NAME:=${MYSQL_ENV_MYSQL_DATABASE:-}}"
 	fi
 
-	file_env 'WORDPRESS_DEBUG'
-	if [ "$WORDPRESS_DEBUG" ]; then
-		set_config 'WP_DEBUG' 1 boolean
-	fi
+	# only touch "wp-config.php" if we have environment-supplied configuration values
+	if [ "$haveConfig" ]; then
+		: "${WORDPRESS_DB_HOST:=mysql}"
+		: "${WORDPRESS_DB_USER:=root}"
+		: "${WORDPRESS_DB_PASSWORD:=}"
+		: "${WORDPRESS_DB_NAME:=wordpress}"
 
-	TERM=dumb php -- "$WORDPRESS_DB_HOST" "$WORDPRESS_DB_USER" "$WORDPRESS_DB_PASSWORD" "$WORDPRESS_DB_NAME" <<'EOPHP'
+		# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
+		# https://github.com/docker-library/wordpress/issues/116
+		# https://github.com/WordPress/WordPress/commit/1acedc542fba2482bab88ec70d4bea4b997a92e4
+		sed -ri -e 's/\r$//' wp-config*
+
+		if [ ! -e wp-config.php ]; then
+			awk '/^\/\*.*stop editing.*\*\/$/ && c == 0 { c = 1; system("cat") } { print }' wp-config-sample.php > wp-config.php <<'EOPHP'
+// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
+// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+	$_SERVER['HTTPS'] = 'on';
+}
+
+EOPHP
+			chown www-data:www-data wp-config.php
+		fi
+
+		# see http://stackoverflow.com/a/2705678/433558
+		sed_escape_lhs() {
+			echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
+		}
+		sed_escape_rhs() {
+			echo "$@" | sed -e 's/[\/&]/\\&/g'
+		}
+		php_escape() {
+			php -r 'var_export(('$2') $argv[1]);' -- "$1"
+		}
+		set_config() {
+			key="$1"
+			value="$2"
+			var_type="${3:-string}"
+			start="(['\"])$(sed_escape_lhs "$key")\2\s*,"
+			end="\);"
+			if [ "${key:0:1}" = '$' ]; then
+				start="^(\s*)$(sed_escape_lhs "$key")\s*="
+				end=";"
+			fi
+			sed -ri -e "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
+		}
+
+		set_config 'DB_HOST' "$WORDPRESS_DB_HOST"
+		set_config 'DB_USER' "$WORDPRESS_DB_USER"
+		set_config 'DB_PASSWORD' "$WORDPRESS_DB_PASSWORD"
+		set_config 'DB_NAME' "$WORDPRESS_DB_NAME"
+
+		for unique in "${uniqueEnvs[@]}"; do
+			uniqVar="WORDPRESS_$unique"
+			if [ -n "${!uniqVar}" ]; then
+				set_config "$unique" "${!uniqVar}"
+			else
+				# if not specified, let's generate a random value
+				currentVal="$(sed -rn -e "s/define\((([\'\"])$unique\2\s*,\s*)(['\"])(.*)\3\);/\4/p" wp-config.php)"
+				if [ "$currentVal" = 'put your unique phrase here' ]; then
+					set_config "$unique" "$(head -c1m /dev/urandom | sha1sum | cut -d' ' -f1)"
+				fi
+			fi
+		done
+
+		if [ "$WORDPRESS_TABLE_PREFIX" ]; then
+			set_config '$table_prefix' "$WORDPRESS_TABLE_PREFIX"
+		fi
+
+		if [ "$WORDPRESS_DEBUG" ]; then
+			set_config 'WP_DEBUG' 1 boolean
+		fi
+
+		TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 
@@ -160,16 +177,19 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = explode(':', $argv[1], 2);
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 
 $maxTries = 10;
 do {
-	$mysql = new mysqli($host, $argv[2], $argv[3], '', $port, $socket);
+	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);
 	if ($mysql->connect_error) {
 		fwrite($stderr, "\n" . 'MySQL Connection Error: (' . $mysql->connect_errno . ') ' . $mysql->connect_error . "\n");
 		--$maxTries;
@@ -180,7 +200,7 @@ do {
 	}
 } while ($mysql->connect_error);
 
-if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_string($argv[4]) . '`')) {
+if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_string($dbName) . '`')) {
 	fwrite($stderr, "\n" . 'MySQL "CREATE DATABASE" Error: ' . $mysql->error . "\n");
 	$mysql->close();
 	exit(1);
@@ -188,6 +208,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 
 $mysql->close();
 EOPHP
+	fi
+
+	# now that we're definitely done writing configuration, let's clear out the relevant envrionment variables (so that stray "phpinfo()" calls don't leak secrets from our code)
+	for e in "${envs[@]}"; do
+		unset "$e"
+	done
 fi
 
 exec "$@"

--- a/php5.6/fpm-alpine/docker-entrypoint.sh
+++ b/php5.6/fpm-alpine/docker-entrypoint.sh
@@ -24,31 +24,14 @@ file_env() {
 }
 
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
-	file_env 'WORDPRESS_DB_HOST' 'mysql'
-	# if we're linked to MySQL and thus have credentials already, let's use them
-	file_env 'WORDPRESS_DB_USER' "${MYSQL_ENV_MYSQL_USER:-root}"
-	if [ "$WORDPRESS_DB_USER" = 'root' ]; then
-		file_env 'WORDPRESS_DB_PASSWORD' "${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}"
-	else
-		file_env 'WORDPRESS_DB_PASSWORD' "${MYSQL_ENV_MYSQL_PASSWORD:-}"
-	fi
-	file_env 'WORDPRESS_DB_NAME' "${MYSQL_ENV_MYSQL_DATABASE:-wordpress}"
-	if [ -z "$WORDPRESS_DB_PASSWORD" ]; then
-		echo >&2 'error: missing required WORDPRESS_DB_PASSWORD environment variable'
-		echo >&2 '  Did you forget to -e WORDPRESS_DB_PASSWORD=... ?'
-		echo >&2
-		echo >&2 '  (Also of interest might be WORDPRESS_DB_USER and WORDPRESS_DB_NAME.)'
-		exit 1
-	fi
-
 	if ! [ -e index.php -a -e wp-includes/version.php ]; then
-		echo >&2 "WordPress not found in $(pwd) - copying now..."
+		echo >&2 "WordPress not found in $PWD - copying now..."
 		if [ "$(ls -A)" ]; then
-			echo >&2 "WARNING: $(pwd) is not empty - press Ctrl+C now if this is an error!"
+			echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
 			( set -x; ls -A; sleep 10 )
 		fi
 		tar cf - --one-file-system -C /usr/src/wordpress . | tar xf -
-		echo >&2 "Complete! WordPress has been successfully copied to $(pwd)"
+		echo >&2 "Complete! WordPress has been successfully copied to $PWD"
 		if [ ! -e .htaccess ]; then
 			# NOTE: The "Indexes" option is disabled in the php:apache base image
 			cat > .htaccess <<-'EOF'
@@ -69,54 +52,9 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
 	# TODO handle WordPress upgrades magically in the same way, but only if wp-includes/version.php's $wp_version is less than /usr/src/wordpress/wp-includes/version.php's $wp_version
 
-	# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
-	# https://github.com/docker-library/wordpress/issues/116
-	# https://github.com/WordPress/WordPress/commit/1acedc542fba2482bab88ec70d4bea4b997a92e4
-	sed -ri -e 's/\r$//' wp-config*
-
-	if [ ! -e wp-config.php ]; then
-		awk '/^\/\*.*stop editing.*\*\/$/ && c == 0 { c = 1; system("cat") } { print }' wp-config-sample.php > wp-config.php <<'EOPHP'
-// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
-// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
-if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
-	$_SERVER['HTTPS'] = 'on';
-}
-
-EOPHP
-		chown www-data:www-data wp-config.php
-	fi
-
-	# see http://stackoverflow.com/a/2705678/433558
-	sed_escape_lhs() {
-		echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
-	}
-	sed_escape_rhs() {
-		echo "$@" | sed -e 's/[\/&]/\\&/g'
-	}
-	php_escape() {
-		php -r 'var_export(('$2') $argv[1]);' -- "$1"
-	}
-	set_config() {
-		key="$1"
-		value="$2"
-		var_type="${3:-string}"
-		start="(['\"])$(sed_escape_lhs "$key")\2\s*,"
-		end="\);"
-		if [ "${key:0:1}" = '$' ]; then
-			start="^(\s*)$(sed_escape_lhs "$key")\s*="
-			end=";"
-		fi
-		sed -ri -e "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
-	}
-
-	set_config 'DB_HOST' "$WORDPRESS_DB_HOST"
-	set_config 'DB_USER' "$WORDPRESS_DB_USER"
-	set_config 'DB_PASSWORD' "$WORDPRESS_DB_PASSWORD"
-	set_config 'DB_NAME' "$WORDPRESS_DB_NAME"
-
 	# allow any of these "Authentication Unique Keys and Salts." to be specified via
 	# environment variables with a "WORDPRESS_" prefix (ie, "WORDPRESS_AUTH_KEY")
-	UNIQUES=(
+	uniqueEnvs=(
 		AUTH_KEY
 		SECURE_AUTH_KEY
 		LOGGED_IN_KEY
@@ -126,31 +64,110 @@ EOPHP
 		LOGGED_IN_SALT
 		NONCE_SALT
 	)
-	for unique in "${UNIQUES[@]}"; do
-		uniqVar="WORDPRESS_$unique"
-		file_env "$uniqVar"
-		if [ "${!uniqVar}" ]; then
-			set_config "$unique" "${!uniqVar}"
-		else
-			# if not specified, let's generate a random value
-			current_set="$(sed -rn -e "s/define\((([\'\"])$unique\2\s*,\s*)(['\"])(.*)\3\);/\4/p" wp-config.php)"
-			if [ "$current_set" = 'put your unique phrase here' ]; then
-				set_config "$unique" "$(head -c1m /dev/urandom | sha1sum | cut -d' ' -f1)"
-			fi
+	envs=(
+		WORDPRESS_DB_HOST
+		WORDPRESS_DB_USER
+		WORDPRESS_DB_PASSWORD
+		WORDPRESS_DB_NAME
+		"${uniqueEnvs[@]/#/WORDPRESS_}"
+		WORDPRESS_TABLE_PREFIX
+		WORDPRESS_DEBUG
+	)
+	haveConfig=
+	for e in "${envs[@]}"; do
+		file_env "$e"
+		if [ -z "$haveConfig" ] && [ -n "${!e}" ]; then
+			haveConfig=1
 		fi
 	done
 
-	file_env 'WORDPRESS_TABLE_PREFIX'
-	if [ "$WORDPRESS_TABLE_PREFIX" ]; then
-		set_config '$table_prefix' "$WORDPRESS_TABLE_PREFIX"
+	# linking backwards-compatibility
+	if [ -n "${!MYSQL_ENV_MYSQL_*}" ]; then
+		haveConfig=1
+		# host defaults to "mysql" below if unspecified
+		: "${WORDPRESS_DB_USER:=${MYSQL_ENV_MYSQL_USER:-root}}"
+		if [ "$WORDPRESS_DB_USER" = 'root' ]; then
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}}"
+		else
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_PASSWORD:-}}"
+		fi
+		: "${WORDPRESS_DB_NAME:=${MYSQL_ENV_MYSQL_DATABASE:-}}"
 	fi
 
-	file_env 'WORDPRESS_DEBUG'
-	if [ "$WORDPRESS_DEBUG" ]; then
-		set_config 'WP_DEBUG' 1 boolean
-	fi
+	# only touch "wp-config.php" if we have environment-supplied configuration values
+	if [ "$haveConfig" ]; then
+		: "${WORDPRESS_DB_HOST:=mysql}"
+		: "${WORDPRESS_DB_USER:=root}"
+		: "${WORDPRESS_DB_PASSWORD:=}"
+		: "${WORDPRESS_DB_NAME:=wordpress}"
 
-	TERM=dumb php -- "$WORDPRESS_DB_HOST" "$WORDPRESS_DB_USER" "$WORDPRESS_DB_PASSWORD" "$WORDPRESS_DB_NAME" <<'EOPHP'
+		# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
+		# https://github.com/docker-library/wordpress/issues/116
+		# https://github.com/WordPress/WordPress/commit/1acedc542fba2482bab88ec70d4bea4b997a92e4
+		sed -ri -e 's/\r$//' wp-config*
+
+		if [ ! -e wp-config.php ]; then
+			awk '/^\/\*.*stop editing.*\*\/$/ && c == 0 { c = 1; system("cat") } { print }' wp-config-sample.php > wp-config.php <<'EOPHP'
+// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
+// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+	$_SERVER['HTTPS'] = 'on';
+}
+
+EOPHP
+			chown www-data:www-data wp-config.php
+		fi
+
+		# see http://stackoverflow.com/a/2705678/433558
+		sed_escape_lhs() {
+			echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
+		}
+		sed_escape_rhs() {
+			echo "$@" | sed -e 's/[\/&]/\\&/g'
+		}
+		php_escape() {
+			php -r 'var_export(('$2') $argv[1]);' -- "$1"
+		}
+		set_config() {
+			key="$1"
+			value="$2"
+			var_type="${3:-string}"
+			start="(['\"])$(sed_escape_lhs "$key")\2\s*,"
+			end="\);"
+			if [ "${key:0:1}" = '$' ]; then
+				start="^(\s*)$(sed_escape_lhs "$key")\s*="
+				end=";"
+			fi
+			sed -ri -e "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
+		}
+
+		set_config 'DB_HOST' "$WORDPRESS_DB_HOST"
+		set_config 'DB_USER' "$WORDPRESS_DB_USER"
+		set_config 'DB_PASSWORD' "$WORDPRESS_DB_PASSWORD"
+		set_config 'DB_NAME' "$WORDPRESS_DB_NAME"
+
+		for unique in "${uniqueEnvs[@]}"; do
+			uniqVar="WORDPRESS_$unique"
+			if [ -n "${!uniqVar}" ]; then
+				set_config "$unique" "${!uniqVar}"
+			else
+				# if not specified, let's generate a random value
+				currentVal="$(sed -rn -e "s/define\((([\'\"])$unique\2\s*,\s*)(['\"])(.*)\3\);/\4/p" wp-config.php)"
+				if [ "$currentVal" = 'put your unique phrase here' ]; then
+					set_config "$unique" "$(head -c1m /dev/urandom | sha1sum | cut -d' ' -f1)"
+				fi
+			fi
+		done
+
+		if [ "$WORDPRESS_TABLE_PREFIX" ]; then
+			set_config '$table_prefix' "$WORDPRESS_TABLE_PREFIX"
+		fi
+
+		if [ "$WORDPRESS_DEBUG" ]; then
+			set_config 'WP_DEBUG' 1 boolean
+		fi
+
+		TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 
@@ -160,16 +177,19 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = explode(':', $argv[1], 2);
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 
 $maxTries = 10;
 do {
-	$mysql = new mysqli($host, $argv[2], $argv[3], '', $port, $socket);
+	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);
 	if ($mysql->connect_error) {
 		fwrite($stderr, "\n" . 'MySQL Connection Error: (' . $mysql->connect_errno . ') ' . $mysql->connect_error . "\n");
 		--$maxTries;
@@ -180,7 +200,7 @@ do {
 	}
 } while ($mysql->connect_error);
 
-if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_string($argv[4]) . '`')) {
+if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_string($dbName) . '`')) {
 	fwrite($stderr, "\n" . 'MySQL "CREATE DATABASE" Error: ' . $mysql->error . "\n");
 	$mysql->close();
 	exit(1);
@@ -188,6 +208,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 
 $mysql->close();
 EOPHP
+	fi
+
+	# now that we're definitely done writing configuration, let's clear out the relevant envrionment variables (so that stray "phpinfo()" calls don't leak secrets from our code)
+	for e in "${envs[@]}"; do
+		unset "$e"
+	done
 fi
 
 exec "$@"

--- a/php5.6/fpm/docker-entrypoint.sh
+++ b/php5.6/fpm/docker-entrypoint.sh
@@ -24,31 +24,14 @@ file_env() {
 }
 
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
-	file_env 'WORDPRESS_DB_HOST' 'mysql'
-	# if we're linked to MySQL and thus have credentials already, let's use them
-	file_env 'WORDPRESS_DB_USER' "${MYSQL_ENV_MYSQL_USER:-root}"
-	if [ "$WORDPRESS_DB_USER" = 'root' ]; then
-		file_env 'WORDPRESS_DB_PASSWORD' "${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}"
-	else
-		file_env 'WORDPRESS_DB_PASSWORD' "${MYSQL_ENV_MYSQL_PASSWORD:-}"
-	fi
-	file_env 'WORDPRESS_DB_NAME' "${MYSQL_ENV_MYSQL_DATABASE:-wordpress}"
-	if [ -z "$WORDPRESS_DB_PASSWORD" ]; then
-		echo >&2 'error: missing required WORDPRESS_DB_PASSWORD environment variable'
-		echo >&2 '  Did you forget to -e WORDPRESS_DB_PASSWORD=... ?'
-		echo >&2
-		echo >&2 '  (Also of interest might be WORDPRESS_DB_USER and WORDPRESS_DB_NAME.)'
-		exit 1
-	fi
-
 	if ! [ -e index.php -a -e wp-includes/version.php ]; then
-		echo >&2 "WordPress not found in $(pwd) - copying now..."
+		echo >&2 "WordPress not found in $PWD - copying now..."
 		if [ "$(ls -A)" ]; then
-			echo >&2 "WARNING: $(pwd) is not empty - press Ctrl+C now if this is an error!"
+			echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
 			( set -x; ls -A; sleep 10 )
 		fi
 		tar cf - --one-file-system -C /usr/src/wordpress . | tar xf -
-		echo >&2 "Complete! WordPress has been successfully copied to $(pwd)"
+		echo >&2 "Complete! WordPress has been successfully copied to $PWD"
 		if [ ! -e .htaccess ]; then
 			# NOTE: The "Indexes" option is disabled in the php:apache base image
 			cat > .htaccess <<-'EOF'
@@ -69,54 +52,9 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
 	# TODO handle WordPress upgrades magically in the same way, but only if wp-includes/version.php's $wp_version is less than /usr/src/wordpress/wp-includes/version.php's $wp_version
 
-	# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
-	# https://github.com/docker-library/wordpress/issues/116
-	# https://github.com/WordPress/WordPress/commit/1acedc542fba2482bab88ec70d4bea4b997a92e4
-	sed -ri -e 's/\r$//' wp-config*
-
-	if [ ! -e wp-config.php ]; then
-		awk '/^\/\*.*stop editing.*\*\/$/ && c == 0 { c = 1; system("cat") } { print }' wp-config-sample.php > wp-config.php <<'EOPHP'
-// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
-// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
-if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
-	$_SERVER['HTTPS'] = 'on';
-}
-
-EOPHP
-		chown www-data:www-data wp-config.php
-	fi
-
-	# see http://stackoverflow.com/a/2705678/433558
-	sed_escape_lhs() {
-		echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
-	}
-	sed_escape_rhs() {
-		echo "$@" | sed -e 's/[\/&]/\\&/g'
-	}
-	php_escape() {
-		php -r 'var_export(('$2') $argv[1]);' -- "$1"
-	}
-	set_config() {
-		key="$1"
-		value="$2"
-		var_type="${3:-string}"
-		start="(['\"])$(sed_escape_lhs "$key")\2\s*,"
-		end="\);"
-		if [ "${key:0:1}" = '$' ]; then
-			start="^(\s*)$(sed_escape_lhs "$key")\s*="
-			end=";"
-		fi
-		sed -ri -e "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
-	}
-
-	set_config 'DB_HOST' "$WORDPRESS_DB_HOST"
-	set_config 'DB_USER' "$WORDPRESS_DB_USER"
-	set_config 'DB_PASSWORD' "$WORDPRESS_DB_PASSWORD"
-	set_config 'DB_NAME' "$WORDPRESS_DB_NAME"
-
 	# allow any of these "Authentication Unique Keys and Salts." to be specified via
 	# environment variables with a "WORDPRESS_" prefix (ie, "WORDPRESS_AUTH_KEY")
-	UNIQUES=(
+	uniqueEnvs=(
 		AUTH_KEY
 		SECURE_AUTH_KEY
 		LOGGED_IN_KEY
@@ -126,31 +64,110 @@ EOPHP
 		LOGGED_IN_SALT
 		NONCE_SALT
 	)
-	for unique in "${UNIQUES[@]}"; do
-		uniqVar="WORDPRESS_$unique"
-		file_env "$uniqVar"
-		if [ "${!uniqVar}" ]; then
-			set_config "$unique" "${!uniqVar}"
-		else
-			# if not specified, let's generate a random value
-			current_set="$(sed -rn -e "s/define\((([\'\"])$unique\2\s*,\s*)(['\"])(.*)\3\);/\4/p" wp-config.php)"
-			if [ "$current_set" = 'put your unique phrase here' ]; then
-				set_config "$unique" "$(head -c1m /dev/urandom | sha1sum | cut -d' ' -f1)"
-			fi
+	envs=(
+		WORDPRESS_DB_HOST
+		WORDPRESS_DB_USER
+		WORDPRESS_DB_PASSWORD
+		WORDPRESS_DB_NAME
+		"${uniqueEnvs[@]/#/WORDPRESS_}"
+		WORDPRESS_TABLE_PREFIX
+		WORDPRESS_DEBUG
+	)
+	haveConfig=
+	for e in "${envs[@]}"; do
+		file_env "$e"
+		if [ -z "$haveConfig" ] && [ -n "${!e}" ]; then
+			haveConfig=1
 		fi
 	done
 
-	file_env 'WORDPRESS_TABLE_PREFIX'
-	if [ "$WORDPRESS_TABLE_PREFIX" ]; then
-		set_config '$table_prefix' "$WORDPRESS_TABLE_PREFIX"
+	# linking backwards-compatibility
+	if [ -n "${!MYSQL_ENV_MYSQL_*}" ]; then
+		haveConfig=1
+		# host defaults to "mysql" below if unspecified
+		: "${WORDPRESS_DB_USER:=${MYSQL_ENV_MYSQL_USER:-root}}"
+		if [ "$WORDPRESS_DB_USER" = 'root' ]; then
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}}"
+		else
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_PASSWORD:-}}"
+		fi
+		: "${WORDPRESS_DB_NAME:=${MYSQL_ENV_MYSQL_DATABASE:-}}"
 	fi
 
-	file_env 'WORDPRESS_DEBUG'
-	if [ "$WORDPRESS_DEBUG" ]; then
-		set_config 'WP_DEBUG' 1 boolean
-	fi
+	# only touch "wp-config.php" if we have environment-supplied configuration values
+	if [ "$haveConfig" ]; then
+		: "${WORDPRESS_DB_HOST:=mysql}"
+		: "${WORDPRESS_DB_USER:=root}"
+		: "${WORDPRESS_DB_PASSWORD:=}"
+		: "${WORDPRESS_DB_NAME:=wordpress}"
 
-	TERM=dumb php -- "$WORDPRESS_DB_HOST" "$WORDPRESS_DB_USER" "$WORDPRESS_DB_PASSWORD" "$WORDPRESS_DB_NAME" <<'EOPHP'
+		# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
+		# https://github.com/docker-library/wordpress/issues/116
+		# https://github.com/WordPress/WordPress/commit/1acedc542fba2482bab88ec70d4bea4b997a92e4
+		sed -ri -e 's/\r$//' wp-config*
+
+		if [ ! -e wp-config.php ]; then
+			awk '/^\/\*.*stop editing.*\*\/$/ && c == 0 { c = 1; system("cat") } { print }' wp-config-sample.php > wp-config.php <<'EOPHP'
+// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
+// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+	$_SERVER['HTTPS'] = 'on';
+}
+
+EOPHP
+			chown www-data:www-data wp-config.php
+		fi
+
+		# see http://stackoverflow.com/a/2705678/433558
+		sed_escape_lhs() {
+			echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
+		}
+		sed_escape_rhs() {
+			echo "$@" | sed -e 's/[\/&]/\\&/g'
+		}
+		php_escape() {
+			php -r 'var_export(('$2') $argv[1]);' -- "$1"
+		}
+		set_config() {
+			key="$1"
+			value="$2"
+			var_type="${3:-string}"
+			start="(['\"])$(sed_escape_lhs "$key")\2\s*,"
+			end="\);"
+			if [ "${key:0:1}" = '$' ]; then
+				start="^(\s*)$(sed_escape_lhs "$key")\s*="
+				end=";"
+			fi
+			sed -ri -e "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
+		}
+
+		set_config 'DB_HOST' "$WORDPRESS_DB_HOST"
+		set_config 'DB_USER' "$WORDPRESS_DB_USER"
+		set_config 'DB_PASSWORD' "$WORDPRESS_DB_PASSWORD"
+		set_config 'DB_NAME' "$WORDPRESS_DB_NAME"
+
+		for unique in "${uniqueEnvs[@]}"; do
+			uniqVar="WORDPRESS_$unique"
+			if [ -n "${!uniqVar}" ]; then
+				set_config "$unique" "${!uniqVar}"
+			else
+				# if not specified, let's generate a random value
+				currentVal="$(sed -rn -e "s/define\((([\'\"])$unique\2\s*,\s*)(['\"])(.*)\3\);/\4/p" wp-config.php)"
+				if [ "$currentVal" = 'put your unique phrase here' ]; then
+					set_config "$unique" "$(head -c1m /dev/urandom | sha1sum | cut -d' ' -f1)"
+				fi
+			fi
+		done
+
+		if [ "$WORDPRESS_TABLE_PREFIX" ]; then
+			set_config '$table_prefix' "$WORDPRESS_TABLE_PREFIX"
+		fi
+
+		if [ "$WORDPRESS_DEBUG" ]; then
+			set_config 'WP_DEBUG' 1 boolean
+		fi
+
+		TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 
@@ -160,16 +177,19 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = explode(':', $argv[1], 2);
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 
 $maxTries = 10;
 do {
-	$mysql = new mysqli($host, $argv[2], $argv[3], '', $port, $socket);
+	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);
 	if ($mysql->connect_error) {
 		fwrite($stderr, "\n" . 'MySQL Connection Error: (' . $mysql->connect_errno . ') ' . $mysql->connect_error . "\n");
 		--$maxTries;
@@ -180,7 +200,7 @@ do {
 	}
 } while ($mysql->connect_error);
 
-if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_string($argv[4]) . '`')) {
+if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_string($dbName) . '`')) {
 	fwrite($stderr, "\n" . 'MySQL "CREATE DATABASE" Error: ' . $mysql->error . "\n");
 	$mysql->close();
 	exit(1);
@@ -188,6 +208,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 
 $mysql->close();
 EOPHP
+	fi
+
+	# now that we're definitely done writing configuration, let's clear out the relevant envrionment variables (so that stray "phpinfo()" calls don't leak secrets from our code)
+	for e in "${envs[@]}"; do
+		unset "$e"
+	done
 fi
 
 exec "$@"

--- a/php7.0/apache/docker-entrypoint.sh
+++ b/php7.0/apache/docker-entrypoint.sh
@@ -24,31 +24,14 @@ file_env() {
 }
 
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
-	file_env 'WORDPRESS_DB_HOST' 'mysql'
-	# if we're linked to MySQL and thus have credentials already, let's use them
-	file_env 'WORDPRESS_DB_USER' "${MYSQL_ENV_MYSQL_USER:-root}"
-	if [ "$WORDPRESS_DB_USER" = 'root' ]; then
-		file_env 'WORDPRESS_DB_PASSWORD' "${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}"
-	else
-		file_env 'WORDPRESS_DB_PASSWORD' "${MYSQL_ENV_MYSQL_PASSWORD:-}"
-	fi
-	file_env 'WORDPRESS_DB_NAME' "${MYSQL_ENV_MYSQL_DATABASE:-wordpress}"
-	if [ -z "$WORDPRESS_DB_PASSWORD" ]; then
-		echo >&2 'error: missing required WORDPRESS_DB_PASSWORD environment variable'
-		echo >&2 '  Did you forget to -e WORDPRESS_DB_PASSWORD=... ?'
-		echo >&2
-		echo >&2 '  (Also of interest might be WORDPRESS_DB_USER and WORDPRESS_DB_NAME.)'
-		exit 1
-	fi
-
 	if ! [ -e index.php -a -e wp-includes/version.php ]; then
-		echo >&2 "WordPress not found in $(pwd) - copying now..."
+		echo >&2 "WordPress not found in $PWD - copying now..."
 		if [ "$(ls -A)" ]; then
-			echo >&2 "WARNING: $(pwd) is not empty - press Ctrl+C now if this is an error!"
+			echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
 			( set -x; ls -A; sleep 10 )
 		fi
 		tar cf - --one-file-system -C /usr/src/wordpress . | tar xf -
-		echo >&2 "Complete! WordPress has been successfully copied to $(pwd)"
+		echo >&2 "Complete! WordPress has been successfully copied to $PWD"
 		if [ ! -e .htaccess ]; then
 			# NOTE: The "Indexes" option is disabled in the php:apache base image
 			cat > .htaccess <<-'EOF'
@@ -69,54 +52,9 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
 	# TODO handle WordPress upgrades magically in the same way, but only if wp-includes/version.php's $wp_version is less than /usr/src/wordpress/wp-includes/version.php's $wp_version
 
-	# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
-	# https://github.com/docker-library/wordpress/issues/116
-	# https://github.com/WordPress/WordPress/commit/1acedc542fba2482bab88ec70d4bea4b997a92e4
-	sed -ri -e 's/\r$//' wp-config*
-
-	if [ ! -e wp-config.php ]; then
-		awk '/^\/\*.*stop editing.*\*\/$/ && c == 0 { c = 1; system("cat") } { print }' wp-config-sample.php > wp-config.php <<'EOPHP'
-// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
-// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
-if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
-	$_SERVER['HTTPS'] = 'on';
-}
-
-EOPHP
-		chown www-data:www-data wp-config.php
-	fi
-
-	# see http://stackoverflow.com/a/2705678/433558
-	sed_escape_lhs() {
-		echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
-	}
-	sed_escape_rhs() {
-		echo "$@" | sed -e 's/[\/&]/\\&/g'
-	}
-	php_escape() {
-		php -r 'var_export(('$2') $argv[1]);' -- "$1"
-	}
-	set_config() {
-		key="$1"
-		value="$2"
-		var_type="${3:-string}"
-		start="(['\"])$(sed_escape_lhs "$key")\2\s*,"
-		end="\);"
-		if [ "${key:0:1}" = '$' ]; then
-			start="^(\s*)$(sed_escape_lhs "$key")\s*="
-			end=";"
-		fi
-		sed -ri -e "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
-	}
-
-	set_config 'DB_HOST' "$WORDPRESS_DB_HOST"
-	set_config 'DB_USER' "$WORDPRESS_DB_USER"
-	set_config 'DB_PASSWORD' "$WORDPRESS_DB_PASSWORD"
-	set_config 'DB_NAME' "$WORDPRESS_DB_NAME"
-
 	# allow any of these "Authentication Unique Keys and Salts." to be specified via
 	# environment variables with a "WORDPRESS_" prefix (ie, "WORDPRESS_AUTH_KEY")
-	UNIQUES=(
+	uniqueEnvs=(
 		AUTH_KEY
 		SECURE_AUTH_KEY
 		LOGGED_IN_KEY
@@ -126,31 +64,110 @@ EOPHP
 		LOGGED_IN_SALT
 		NONCE_SALT
 	)
-	for unique in "${UNIQUES[@]}"; do
-		uniqVar="WORDPRESS_$unique"
-		file_env "$uniqVar"
-		if [ "${!uniqVar}" ]; then
-			set_config "$unique" "${!uniqVar}"
-		else
-			# if not specified, let's generate a random value
-			current_set="$(sed -rn -e "s/define\((([\'\"])$unique\2\s*,\s*)(['\"])(.*)\3\);/\4/p" wp-config.php)"
-			if [ "$current_set" = 'put your unique phrase here' ]; then
-				set_config "$unique" "$(head -c1m /dev/urandom | sha1sum | cut -d' ' -f1)"
-			fi
+	envs=(
+		WORDPRESS_DB_HOST
+		WORDPRESS_DB_USER
+		WORDPRESS_DB_PASSWORD
+		WORDPRESS_DB_NAME
+		"${uniqueEnvs[@]/#/WORDPRESS_}"
+		WORDPRESS_TABLE_PREFIX
+		WORDPRESS_DEBUG
+	)
+	haveConfig=
+	for e in "${envs[@]}"; do
+		file_env "$e"
+		if [ -z "$haveConfig" ] && [ -n "${!e}" ]; then
+			haveConfig=1
 		fi
 	done
 
-	file_env 'WORDPRESS_TABLE_PREFIX'
-	if [ "$WORDPRESS_TABLE_PREFIX" ]; then
-		set_config '$table_prefix' "$WORDPRESS_TABLE_PREFIX"
+	# linking backwards-compatibility
+	if [ -n "${!MYSQL_ENV_MYSQL_*}" ]; then
+		haveConfig=1
+		# host defaults to "mysql" below if unspecified
+		: "${WORDPRESS_DB_USER:=${MYSQL_ENV_MYSQL_USER:-root}}"
+		if [ "$WORDPRESS_DB_USER" = 'root' ]; then
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}}"
+		else
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_PASSWORD:-}}"
+		fi
+		: "${WORDPRESS_DB_NAME:=${MYSQL_ENV_MYSQL_DATABASE:-}}"
 	fi
 
-	file_env 'WORDPRESS_DEBUG'
-	if [ "$WORDPRESS_DEBUG" ]; then
-		set_config 'WP_DEBUG' 1 boolean
-	fi
+	# only touch "wp-config.php" if we have environment-supplied configuration values
+	if [ "$haveConfig" ]; then
+		: "${WORDPRESS_DB_HOST:=mysql}"
+		: "${WORDPRESS_DB_USER:=root}"
+		: "${WORDPRESS_DB_PASSWORD:=}"
+		: "${WORDPRESS_DB_NAME:=wordpress}"
 
-	TERM=dumb php -- "$WORDPRESS_DB_HOST" "$WORDPRESS_DB_USER" "$WORDPRESS_DB_PASSWORD" "$WORDPRESS_DB_NAME" <<'EOPHP'
+		# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
+		# https://github.com/docker-library/wordpress/issues/116
+		# https://github.com/WordPress/WordPress/commit/1acedc542fba2482bab88ec70d4bea4b997a92e4
+		sed -ri -e 's/\r$//' wp-config*
+
+		if [ ! -e wp-config.php ]; then
+			awk '/^\/\*.*stop editing.*\*\/$/ && c == 0 { c = 1; system("cat") } { print }' wp-config-sample.php > wp-config.php <<'EOPHP'
+// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
+// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+	$_SERVER['HTTPS'] = 'on';
+}
+
+EOPHP
+			chown www-data:www-data wp-config.php
+		fi
+
+		# see http://stackoverflow.com/a/2705678/433558
+		sed_escape_lhs() {
+			echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
+		}
+		sed_escape_rhs() {
+			echo "$@" | sed -e 's/[\/&]/\\&/g'
+		}
+		php_escape() {
+			php -r 'var_export(('$2') $argv[1]);' -- "$1"
+		}
+		set_config() {
+			key="$1"
+			value="$2"
+			var_type="${3:-string}"
+			start="(['\"])$(sed_escape_lhs "$key")\2\s*,"
+			end="\);"
+			if [ "${key:0:1}" = '$' ]; then
+				start="^(\s*)$(sed_escape_lhs "$key")\s*="
+				end=";"
+			fi
+			sed -ri -e "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
+		}
+
+		set_config 'DB_HOST' "$WORDPRESS_DB_HOST"
+		set_config 'DB_USER' "$WORDPRESS_DB_USER"
+		set_config 'DB_PASSWORD' "$WORDPRESS_DB_PASSWORD"
+		set_config 'DB_NAME' "$WORDPRESS_DB_NAME"
+
+		for unique in "${uniqueEnvs[@]}"; do
+			uniqVar="WORDPRESS_$unique"
+			if [ -n "${!uniqVar}" ]; then
+				set_config "$unique" "${!uniqVar}"
+			else
+				# if not specified, let's generate a random value
+				currentVal="$(sed -rn -e "s/define\((([\'\"])$unique\2\s*,\s*)(['\"])(.*)\3\);/\4/p" wp-config.php)"
+				if [ "$currentVal" = 'put your unique phrase here' ]; then
+					set_config "$unique" "$(head -c1m /dev/urandom | sha1sum | cut -d' ' -f1)"
+				fi
+			fi
+		done
+
+		if [ "$WORDPRESS_TABLE_PREFIX" ]; then
+			set_config '$table_prefix' "$WORDPRESS_TABLE_PREFIX"
+		fi
+
+		if [ "$WORDPRESS_DEBUG" ]; then
+			set_config 'WP_DEBUG' 1 boolean
+		fi
+
+		TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 
@@ -160,16 +177,19 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = explode(':', $argv[1], 2);
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 
 $maxTries = 10;
 do {
-	$mysql = new mysqli($host, $argv[2], $argv[3], '', $port, $socket);
+	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);
 	if ($mysql->connect_error) {
 		fwrite($stderr, "\n" . 'MySQL Connection Error: (' . $mysql->connect_errno . ') ' . $mysql->connect_error . "\n");
 		--$maxTries;
@@ -180,7 +200,7 @@ do {
 	}
 } while ($mysql->connect_error);
 
-if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_string($argv[4]) . '`')) {
+if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_string($dbName) . '`')) {
 	fwrite($stderr, "\n" . 'MySQL "CREATE DATABASE" Error: ' . $mysql->error . "\n");
 	$mysql->close();
 	exit(1);
@@ -188,6 +208,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 
 $mysql->close();
 EOPHP
+	fi
+
+	# now that we're definitely done writing configuration, let's clear out the relevant envrionment variables (so that stray "phpinfo()" calls don't leak secrets from our code)
+	for e in "${envs[@]}"; do
+		unset "$e"
+	done
 fi
 
 exec "$@"

--- a/php7.0/fpm-alpine/docker-entrypoint.sh
+++ b/php7.0/fpm-alpine/docker-entrypoint.sh
@@ -24,31 +24,14 @@ file_env() {
 }
 
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
-	file_env 'WORDPRESS_DB_HOST' 'mysql'
-	# if we're linked to MySQL and thus have credentials already, let's use them
-	file_env 'WORDPRESS_DB_USER' "${MYSQL_ENV_MYSQL_USER:-root}"
-	if [ "$WORDPRESS_DB_USER" = 'root' ]; then
-		file_env 'WORDPRESS_DB_PASSWORD' "${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}"
-	else
-		file_env 'WORDPRESS_DB_PASSWORD' "${MYSQL_ENV_MYSQL_PASSWORD:-}"
-	fi
-	file_env 'WORDPRESS_DB_NAME' "${MYSQL_ENV_MYSQL_DATABASE:-wordpress}"
-	if [ -z "$WORDPRESS_DB_PASSWORD" ]; then
-		echo >&2 'error: missing required WORDPRESS_DB_PASSWORD environment variable'
-		echo >&2 '  Did you forget to -e WORDPRESS_DB_PASSWORD=... ?'
-		echo >&2
-		echo >&2 '  (Also of interest might be WORDPRESS_DB_USER and WORDPRESS_DB_NAME.)'
-		exit 1
-	fi
-
 	if ! [ -e index.php -a -e wp-includes/version.php ]; then
-		echo >&2 "WordPress not found in $(pwd) - copying now..."
+		echo >&2 "WordPress not found in $PWD - copying now..."
 		if [ "$(ls -A)" ]; then
-			echo >&2 "WARNING: $(pwd) is not empty - press Ctrl+C now if this is an error!"
+			echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
 			( set -x; ls -A; sleep 10 )
 		fi
 		tar cf - --one-file-system -C /usr/src/wordpress . | tar xf -
-		echo >&2 "Complete! WordPress has been successfully copied to $(pwd)"
+		echo >&2 "Complete! WordPress has been successfully copied to $PWD"
 		if [ ! -e .htaccess ]; then
 			# NOTE: The "Indexes" option is disabled in the php:apache base image
 			cat > .htaccess <<-'EOF'
@@ -69,54 +52,9 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
 	# TODO handle WordPress upgrades magically in the same way, but only if wp-includes/version.php's $wp_version is less than /usr/src/wordpress/wp-includes/version.php's $wp_version
 
-	# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
-	# https://github.com/docker-library/wordpress/issues/116
-	# https://github.com/WordPress/WordPress/commit/1acedc542fba2482bab88ec70d4bea4b997a92e4
-	sed -ri -e 's/\r$//' wp-config*
-
-	if [ ! -e wp-config.php ]; then
-		awk '/^\/\*.*stop editing.*\*\/$/ && c == 0 { c = 1; system("cat") } { print }' wp-config-sample.php > wp-config.php <<'EOPHP'
-// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
-// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
-if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
-	$_SERVER['HTTPS'] = 'on';
-}
-
-EOPHP
-		chown www-data:www-data wp-config.php
-	fi
-
-	# see http://stackoverflow.com/a/2705678/433558
-	sed_escape_lhs() {
-		echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
-	}
-	sed_escape_rhs() {
-		echo "$@" | sed -e 's/[\/&]/\\&/g'
-	}
-	php_escape() {
-		php -r 'var_export(('$2') $argv[1]);' -- "$1"
-	}
-	set_config() {
-		key="$1"
-		value="$2"
-		var_type="${3:-string}"
-		start="(['\"])$(sed_escape_lhs "$key")\2\s*,"
-		end="\);"
-		if [ "${key:0:1}" = '$' ]; then
-			start="^(\s*)$(sed_escape_lhs "$key")\s*="
-			end=";"
-		fi
-		sed -ri -e "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
-	}
-
-	set_config 'DB_HOST' "$WORDPRESS_DB_HOST"
-	set_config 'DB_USER' "$WORDPRESS_DB_USER"
-	set_config 'DB_PASSWORD' "$WORDPRESS_DB_PASSWORD"
-	set_config 'DB_NAME' "$WORDPRESS_DB_NAME"
-
 	# allow any of these "Authentication Unique Keys and Salts." to be specified via
 	# environment variables with a "WORDPRESS_" prefix (ie, "WORDPRESS_AUTH_KEY")
-	UNIQUES=(
+	uniqueEnvs=(
 		AUTH_KEY
 		SECURE_AUTH_KEY
 		LOGGED_IN_KEY
@@ -126,31 +64,110 @@ EOPHP
 		LOGGED_IN_SALT
 		NONCE_SALT
 	)
-	for unique in "${UNIQUES[@]}"; do
-		uniqVar="WORDPRESS_$unique"
-		file_env "$uniqVar"
-		if [ "${!uniqVar}" ]; then
-			set_config "$unique" "${!uniqVar}"
-		else
-			# if not specified, let's generate a random value
-			current_set="$(sed -rn -e "s/define\((([\'\"])$unique\2\s*,\s*)(['\"])(.*)\3\);/\4/p" wp-config.php)"
-			if [ "$current_set" = 'put your unique phrase here' ]; then
-				set_config "$unique" "$(head -c1m /dev/urandom | sha1sum | cut -d' ' -f1)"
-			fi
+	envs=(
+		WORDPRESS_DB_HOST
+		WORDPRESS_DB_USER
+		WORDPRESS_DB_PASSWORD
+		WORDPRESS_DB_NAME
+		"${uniqueEnvs[@]/#/WORDPRESS_}"
+		WORDPRESS_TABLE_PREFIX
+		WORDPRESS_DEBUG
+	)
+	haveConfig=
+	for e in "${envs[@]}"; do
+		file_env "$e"
+		if [ -z "$haveConfig" ] && [ -n "${!e}" ]; then
+			haveConfig=1
 		fi
 	done
 
-	file_env 'WORDPRESS_TABLE_PREFIX'
-	if [ "$WORDPRESS_TABLE_PREFIX" ]; then
-		set_config '$table_prefix' "$WORDPRESS_TABLE_PREFIX"
+	# linking backwards-compatibility
+	if [ -n "${!MYSQL_ENV_MYSQL_*}" ]; then
+		haveConfig=1
+		# host defaults to "mysql" below if unspecified
+		: "${WORDPRESS_DB_USER:=${MYSQL_ENV_MYSQL_USER:-root}}"
+		if [ "$WORDPRESS_DB_USER" = 'root' ]; then
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}}"
+		else
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_PASSWORD:-}}"
+		fi
+		: "${WORDPRESS_DB_NAME:=${MYSQL_ENV_MYSQL_DATABASE:-}}"
 	fi
 
-	file_env 'WORDPRESS_DEBUG'
-	if [ "$WORDPRESS_DEBUG" ]; then
-		set_config 'WP_DEBUG' 1 boolean
-	fi
+	# only touch "wp-config.php" if we have environment-supplied configuration values
+	if [ "$haveConfig" ]; then
+		: "${WORDPRESS_DB_HOST:=mysql}"
+		: "${WORDPRESS_DB_USER:=root}"
+		: "${WORDPRESS_DB_PASSWORD:=}"
+		: "${WORDPRESS_DB_NAME:=wordpress}"
 
-	TERM=dumb php -- "$WORDPRESS_DB_HOST" "$WORDPRESS_DB_USER" "$WORDPRESS_DB_PASSWORD" "$WORDPRESS_DB_NAME" <<'EOPHP'
+		# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
+		# https://github.com/docker-library/wordpress/issues/116
+		# https://github.com/WordPress/WordPress/commit/1acedc542fba2482bab88ec70d4bea4b997a92e4
+		sed -ri -e 's/\r$//' wp-config*
+
+		if [ ! -e wp-config.php ]; then
+			awk '/^\/\*.*stop editing.*\*\/$/ && c == 0 { c = 1; system("cat") } { print }' wp-config-sample.php > wp-config.php <<'EOPHP'
+// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
+// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+	$_SERVER['HTTPS'] = 'on';
+}
+
+EOPHP
+			chown www-data:www-data wp-config.php
+		fi
+
+		# see http://stackoverflow.com/a/2705678/433558
+		sed_escape_lhs() {
+			echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
+		}
+		sed_escape_rhs() {
+			echo "$@" | sed -e 's/[\/&]/\\&/g'
+		}
+		php_escape() {
+			php -r 'var_export(('$2') $argv[1]);' -- "$1"
+		}
+		set_config() {
+			key="$1"
+			value="$2"
+			var_type="${3:-string}"
+			start="(['\"])$(sed_escape_lhs "$key")\2\s*,"
+			end="\);"
+			if [ "${key:0:1}" = '$' ]; then
+				start="^(\s*)$(sed_escape_lhs "$key")\s*="
+				end=";"
+			fi
+			sed -ri -e "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
+		}
+
+		set_config 'DB_HOST' "$WORDPRESS_DB_HOST"
+		set_config 'DB_USER' "$WORDPRESS_DB_USER"
+		set_config 'DB_PASSWORD' "$WORDPRESS_DB_PASSWORD"
+		set_config 'DB_NAME' "$WORDPRESS_DB_NAME"
+
+		for unique in "${uniqueEnvs[@]}"; do
+			uniqVar="WORDPRESS_$unique"
+			if [ -n "${!uniqVar}" ]; then
+				set_config "$unique" "${!uniqVar}"
+			else
+				# if not specified, let's generate a random value
+				currentVal="$(sed -rn -e "s/define\((([\'\"])$unique\2\s*,\s*)(['\"])(.*)\3\);/\4/p" wp-config.php)"
+				if [ "$currentVal" = 'put your unique phrase here' ]; then
+					set_config "$unique" "$(head -c1m /dev/urandom | sha1sum | cut -d' ' -f1)"
+				fi
+			fi
+		done
+
+		if [ "$WORDPRESS_TABLE_PREFIX" ]; then
+			set_config '$table_prefix' "$WORDPRESS_TABLE_PREFIX"
+		fi
+
+		if [ "$WORDPRESS_DEBUG" ]; then
+			set_config 'WP_DEBUG' 1 boolean
+		fi
+
+		TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 
@@ -160,16 +177,19 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = explode(':', $argv[1], 2);
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 
 $maxTries = 10;
 do {
-	$mysql = new mysqli($host, $argv[2], $argv[3], '', $port, $socket);
+	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);
 	if ($mysql->connect_error) {
 		fwrite($stderr, "\n" . 'MySQL Connection Error: (' . $mysql->connect_errno . ') ' . $mysql->connect_error . "\n");
 		--$maxTries;
@@ -180,7 +200,7 @@ do {
 	}
 } while ($mysql->connect_error);
 
-if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_string($argv[4]) . '`')) {
+if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_string($dbName) . '`')) {
 	fwrite($stderr, "\n" . 'MySQL "CREATE DATABASE" Error: ' . $mysql->error . "\n");
 	$mysql->close();
 	exit(1);
@@ -188,6 +208,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 
 $mysql->close();
 EOPHP
+	fi
+
+	# now that we're definitely done writing configuration, let's clear out the relevant envrionment variables (so that stray "phpinfo()" calls don't leak secrets from our code)
+	for e in "${envs[@]}"; do
+		unset "$e"
+	done
 fi
 
 exec "$@"

--- a/php7.0/fpm/docker-entrypoint.sh
+++ b/php7.0/fpm/docker-entrypoint.sh
@@ -24,31 +24,14 @@ file_env() {
 }
 
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
-	file_env 'WORDPRESS_DB_HOST' 'mysql'
-	# if we're linked to MySQL and thus have credentials already, let's use them
-	file_env 'WORDPRESS_DB_USER' "${MYSQL_ENV_MYSQL_USER:-root}"
-	if [ "$WORDPRESS_DB_USER" = 'root' ]; then
-		file_env 'WORDPRESS_DB_PASSWORD' "${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}"
-	else
-		file_env 'WORDPRESS_DB_PASSWORD' "${MYSQL_ENV_MYSQL_PASSWORD:-}"
-	fi
-	file_env 'WORDPRESS_DB_NAME' "${MYSQL_ENV_MYSQL_DATABASE:-wordpress}"
-	if [ -z "$WORDPRESS_DB_PASSWORD" ]; then
-		echo >&2 'error: missing required WORDPRESS_DB_PASSWORD environment variable'
-		echo >&2 '  Did you forget to -e WORDPRESS_DB_PASSWORD=... ?'
-		echo >&2
-		echo >&2 '  (Also of interest might be WORDPRESS_DB_USER and WORDPRESS_DB_NAME.)'
-		exit 1
-	fi
-
 	if ! [ -e index.php -a -e wp-includes/version.php ]; then
-		echo >&2 "WordPress not found in $(pwd) - copying now..."
+		echo >&2 "WordPress not found in $PWD - copying now..."
 		if [ "$(ls -A)" ]; then
-			echo >&2 "WARNING: $(pwd) is not empty - press Ctrl+C now if this is an error!"
+			echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
 			( set -x; ls -A; sleep 10 )
 		fi
 		tar cf - --one-file-system -C /usr/src/wordpress . | tar xf -
-		echo >&2 "Complete! WordPress has been successfully copied to $(pwd)"
+		echo >&2 "Complete! WordPress has been successfully copied to $PWD"
 		if [ ! -e .htaccess ]; then
 			# NOTE: The "Indexes" option is disabled in the php:apache base image
 			cat > .htaccess <<-'EOF'
@@ -69,54 +52,9 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
 	# TODO handle WordPress upgrades magically in the same way, but only if wp-includes/version.php's $wp_version is less than /usr/src/wordpress/wp-includes/version.php's $wp_version
 
-	# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
-	# https://github.com/docker-library/wordpress/issues/116
-	# https://github.com/WordPress/WordPress/commit/1acedc542fba2482bab88ec70d4bea4b997a92e4
-	sed -ri -e 's/\r$//' wp-config*
-
-	if [ ! -e wp-config.php ]; then
-		awk '/^\/\*.*stop editing.*\*\/$/ && c == 0 { c = 1; system("cat") } { print }' wp-config-sample.php > wp-config.php <<'EOPHP'
-// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
-// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
-if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
-	$_SERVER['HTTPS'] = 'on';
-}
-
-EOPHP
-		chown www-data:www-data wp-config.php
-	fi
-
-	# see http://stackoverflow.com/a/2705678/433558
-	sed_escape_lhs() {
-		echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
-	}
-	sed_escape_rhs() {
-		echo "$@" | sed -e 's/[\/&]/\\&/g'
-	}
-	php_escape() {
-		php -r 'var_export(('$2') $argv[1]);' -- "$1"
-	}
-	set_config() {
-		key="$1"
-		value="$2"
-		var_type="${3:-string}"
-		start="(['\"])$(sed_escape_lhs "$key")\2\s*,"
-		end="\);"
-		if [ "${key:0:1}" = '$' ]; then
-			start="^(\s*)$(sed_escape_lhs "$key")\s*="
-			end=";"
-		fi
-		sed -ri -e "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
-	}
-
-	set_config 'DB_HOST' "$WORDPRESS_DB_HOST"
-	set_config 'DB_USER' "$WORDPRESS_DB_USER"
-	set_config 'DB_PASSWORD' "$WORDPRESS_DB_PASSWORD"
-	set_config 'DB_NAME' "$WORDPRESS_DB_NAME"
-
 	# allow any of these "Authentication Unique Keys and Salts." to be specified via
 	# environment variables with a "WORDPRESS_" prefix (ie, "WORDPRESS_AUTH_KEY")
-	UNIQUES=(
+	uniqueEnvs=(
 		AUTH_KEY
 		SECURE_AUTH_KEY
 		LOGGED_IN_KEY
@@ -126,31 +64,110 @@ EOPHP
 		LOGGED_IN_SALT
 		NONCE_SALT
 	)
-	for unique in "${UNIQUES[@]}"; do
-		uniqVar="WORDPRESS_$unique"
-		file_env "$uniqVar"
-		if [ "${!uniqVar}" ]; then
-			set_config "$unique" "${!uniqVar}"
-		else
-			# if not specified, let's generate a random value
-			current_set="$(sed -rn -e "s/define\((([\'\"])$unique\2\s*,\s*)(['\"])(.*)\3\);/\4/p" wp-config.php)"
-			if [ "$current_set" = 'put your unique phrase here' ]; then
-				set_config "$unique" "$(head -c1m /dev/urandom | sha1sum | cut -d' ' -f1)"
-			fi
+	envs=(
+		WORDPRESS_DB_HOST
+		WORDPRESS_DB_USER
+		WORDPRESS_DB_PASSWORD
+		WORDPRESS_DB_NAME
+		"${uniqueEnvs[@]/#/WORDPRESS_}"
+		WORDPRESS_TABLE_PREFIX
+		WORDPRESS_DEBUG
+	)
+	haveConfig=
+	for e in "${envs[@]}"; do
+		file_env "$e"
+		if [ -z "$haveConfig" ] && [ -n "${!e}" ]; then
+			haveConfig=1
 		fi
 	done
 
-	file_env 'WORDPRESS_TABLE_PREFIX'
-	if [ "$WORDPRESS_TABLE_PREFIX" ]; then
-		set_config '$table_prefix' "$WORDPRESS_TABLE_PREFIX"
+	# linking backwards-compatibility
+	if [ -n "${!MYSQL_ENV_MYSQL_*}" ]; then
+		haveConfig=1
+		# host defaults to "mysql" below if unspecified
+		: "${WORDPRESS_DB_USER:=${MYSQL_ENV_MYSQL_USER:-root}}"
+		if [ "$WORDPRESS_DB_USER" = 'root' ]; then
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}}"
+		else
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_PASSWORD:-}}"
+		fi
+		: "${WORDPRESS_DB_NAME:=${MYSQL_ENV_MYSQL_DATABASE:-}}"
 	fi
 
-	file_env 'WORDPRESS_DEBUG'
-	if [ "$WORDPRESS_DEBUG" ]; then
-		set_config 'WP_DEBUG' 1 boolean
-	fi
+	# only touch "wp-config.php" if we have environment-supplied configuration values
+	if [ "$haveConfig" ]; then
+		: "${WORDPRESS_DB_HOST:=mysql}"
+		: "${WORDPRESS_DB_USER:=root}"
+		: "${WORDPRESS_DB_PASSWORD:=}"
+		: "${WORDPRESS_DB_NAME:=wordpress}"
 
-	TERM=dumb php -- "$WORDPRESS_DB_HOST" "$WORDPRESS_DB_USER" "$WORDPRESS_DB_PASSWORD" "$WORDPRESS_DB_NAME" <<'EOPHP'
+		# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
+		# https://github.com/docker-library/wordpress/issues/116
+		# https://github.com/WordPress/WordPress/commit/1acedc542fba2482bab88ec70d4bea4b997a92e4
+		sed -ri -e 's/\r$//' wp-config*
+
+		if [ ! -e wp-config.php ]; then
+			awk '/^\/\*.*stop editing.*\*\/$/ && c == 0 { c = 1; system("cat") } { print }' wp-config-sample.php > wp-config.php <<'EOPHP'
+// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
+// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+	$_SERVER['HTTPS'] = 'on';
+}
+
+EOPHP
+			chown www-data:www-data wp-config.php
+		fi
+
+		# see http://stackoverflow.com/a/2705678/433558
+		sed_escape_lhs() {
+			echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
+		}
+		sed_escape_rhs() {
+			echo "$@" | sed -e 's/[\/&]/\\&/g'
+		}
+		php_escape() {
+			php -r 'var_export(('$2') $argv[1]);' -- "$1"
+		}
+		set_config() {
+			key="$1"
+			value="$2"
+			var_type="${3:-string}"
+			start="(['\"])$(sed_escape_lhs "$key")\2\s*,"
+			end="\);"
+			if [ "${key:0:1}" = '$' ]; then
+				start="^(\s*)$(sed_escape_lhs "$key")\s*="
+				end=";"
+			fi
+			sed -ri -e "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
+		}
+
+		set_config 'DB_HOST' "$WORDPRESS_DB_HOST"
+		set_config 'DB_USER' "$WORDPRESS_DB_USER"
+		set_config 'DB_PASSWORD' "$WORDPRESS_DB_PASSWORD"
+		set_config 'DB_NAME' "$WORDPRESS_DB_NAME"
+
+		for unique in "${uniqueEnvs[@]}"; do
+			uniqVar="WORDPRESS_$unique"
+			if [ -n "${!uniqVar}" ]; then
+				set_config "$unique" "${!uniqVar}"
+			else
+				# if not specified, let's generate a random value
+				currentVal="$(sed -rn -e "s/define\((([\'\"])$unique\2\s*,\s*)(['\"])(.*)\3\);/\4/p" wp-config.php)"
+				if [ "$currentVal" = 'put your unique phrase here' ]; then
+					set_config "$unique" "$(head -c1m /dev/urandom | sha1sum | cut -d' ' -f1)"
+				fi
+			fi
+		done
+
+		if [ "$WORDPRESS_TABLE_PREFIX" ]; then
+			set_config '$table_prefix' "$WORDPRESS_TABLE_PREFIX"
+		fi
+
+		if [ "$WORDPRESS_DEBUG" ]; then
+			set_config 'WP_DEBUG' 1 boolean
+		fi
+
+		TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 
@@ -160,16 +177,19 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = explode(':', $argv[1], 2);
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 
 $maxTries = 10;
 do {
-	$mysql = new mysqli($host, $argv[2], $argv[3], '', $port, $socket);
+	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);
 	if ($mysql->connect_error) {
 		fwrite($stderr, "\n" . 'MySQL Connection Error: (' . $mysql->connect_errno . ') ' . $mysql->connect_error . "\n");
 		--$maxTries;
@@ -180,7 +200,7 @@ do {
 	}
 } while ($mysql->connect_error);
 
-if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_string($argv[4]) . '`')) {
+if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_string($dbName) . '`')) {
 	fwrite($stderr, "\n" . 'MySQL "CREATE DATABASE" Error: ' . $mysql->error . "\n");
 	$mysql->close();
 	exit(1);
@@ -188,6 +208,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 
 $mysql->close();
 EOPHP
+	fi
+
+	# now that we're definitely done writing configuration, let's clear out the relevant envrionment variables (so that stray "phpinfo()" calls don't leak secrets from our code)
+	for e in "${envs[@]}"; do
+		unset "$e"
+	done
 fi
 
 exec "$@"

--- a/php7.1/apache/docker-entrypoint.sh
+++ b/php7.1/apache/docker-entrypoint.sh
@@ -24,31 +24,14 @@ file_env() {
 }
 
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
-	file_env 'WORDPRESS_DB_HOST' 'mysql'
-	# if we're linked to MySQL and thus have credentials already, let's use them
-	file_env 'WORDPRESS_DB_USER' "${MYSQL_ENV_MYSQL_USER:-root}"
-	if [ "$WORDPRESS_DB_USER" = 'root' ]; then
-		file_env 'WORDPRESS_DB_PASSWORD' "${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}"
-	else
-		file_env 'WORDPRESS_DB_PASSWORD' "${MYSQL_ENV_MYSQL_PASSWORD:-}"
-	fi
-	file_env 'WORDPRESS_DB_NAME' "${MYSQL_ENV_MYSQL_DATABASE:-wordpress}"
-	if [ -z "$WORDPRESS_DB_PASSWORD" ]; then
-		echo >&2 'error: missing required WORDPRESS_DB_PASSWORD environment variable'
-		echo >&2 '  Did you forget to -e WORDPRESS_DB_PASSWORD=... ?'
-		echo >&2
-		echo >&2 '  (Also of interest might be WORDPRESS_DB_USER and WORDPRESS_DB_NAME.)'
-		exit 1
-	fi
-
 	if ! [ -e index.php -a -e wp-includes/version.php ]; then
-		echo >&2 "WordPress not found in $(pwd) - copying now..."
+		echo >&2 "WordPress not found in $PWD - copying now..."
 		if [ "$(ls -A)" ]; then
-			echo >&2 "WARNING: $(pwd) is not empty - press Ctrl+C now if this is an error!"
+			echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
 			( set -x; ls -A; sleep 10 )
 		fi
 		tar cf - --one-file-system -C /usr/src/wordpress . | tar xf -
-		echo >&2 "Complete! WordPress has been successfully copied to $(pwd)"
+		echo >&2 "Complete! WordPress has been successfully copied to $PWD"
 		if [ ! -e .htaccess ]; then
 			# NOTE: The "Indexes" option is disabled in the php:apache base image
 			cat > .htaccess <<-'EOF'
@@ -69,54 +52,9 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
 	# TODO handle WordPress upgrades magically in the same way, but only if wp-includes/version.php's $wp_version is less than /usr/src/wordpress/wp-includes/version.php's $wp_version
 
-	# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
-	# https://github.com/docker-library/wordpress/issues/116
-	# https://github.com/WordPress/WordPress/commit/1acedc542fba2482bab88ec70d4bea4b997a92e4
-	sed -ri -e 's/\r$//' wp-config*
-
-	if [ ! -e wp-config.php ]; then
-		awk '/^\/\*.*stop editing.*\*\/$/ && c == 0 { c = 1; system("cat") } { print }' wp-config-sample.php > wp-config.php <<'EOPHP'
-// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
-// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
-if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
-	$_SERVER['HTTPS'] = 'on';
-}
-
-EOPHP
-		chown www-data:www-data wp-config.php
-	fi
-
-	# see http://stackoverflow.com/a/2705678/433558
-	sed_escape_lhs() {
-		echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
-	}
-	sed_escape_rhs() {
-		echo "$@" | sed -e 's/[\/&]/\\&/g'
-	}
-	php_escape() {
-		php -r 'var_export(('$2') $argv[1]);' -- "$1"
-	}
-	set_config() {
-		key="$1"
-		value="$2"
-		var_type="${3:-string}"
-		start="(['\"])$(sed_escape_lhs "$key")\2\s*,"
-		end="\);"
-		if [ "${key:0:1}" = '$' ]; then
-			start="^(\s*)$(sed_escape_lhs "$key")\s*="
-			end=";"
-		fi
-		sed -ri -e "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
-	}
-
-	set_config 'DB_HOST' "$WORDPRESS_DB_HOST"
-	set_config 'DB_USER' "$WORDPRESS_DB_USER"
-	set_config 'DB_PASSWORD' "$WORDPRESS_DB_PASSWORD"
-	set_config 'DB_NAME' "$WORDPRESS_DB_NAME"
-
 	# allow any of these "Authentication Unique Keys and Salts." to be specified via
 	# environment variables with a "WORDPRESS_" prefix (ie, "WORDPRESS_AUTH_KEY")
-	UNIQUES=(
+	uniqueEnvs=(
 		AUTH_KEY
 		SECURE_AUTH_KEY
 		LOGGED_IN_KEY
@@ -126,31 +64,110 @@ EOPHP
 		LOGGED_IN_SALT
 		NONCE_SALT
 	)
-	for unique in "${UNIQUES[@]}"; do
-		uniqVar="WORDPRESS_$unique"
-		file_env "$uniqVar"
-		if [ "${!uniqVar}" ]; then
-			set_config "$unique" "${!uniqVar}"
-		else
-			# if not specified, let's generate a random value
-			current_set="$(sed -rn -e "s/define\((([\'\"])$unique\2\s*,\s*)(['\"])(.*)\3\);/\4/p" wp-config.php)"
-			if [ "$current_set" = 'put your unique phrase here' ]; then
-				set_config "$unique" "$(head -c1m /dev/urandom | sha1sum | cut -d' ' -f1)"
-			fi
+	envs=(
+		WORDPRESS_DB_HOST
+		WORDPRESS_DB_USER
+		WORDPRESS_DB_PASSWORD
+		WORDPRESS_DB_NAME
+		"${uniqueEnvs[@]/#/WORDPRESS_}"
+		WORDPRESS_TABLE_PREFIX
+		WORDPRESS_DEBUG
+	)
+	haveConfig=
+	for e in "${envs[@]}"; do
+		file_env "$e"
+		if [ -z "$haveConfig" ] && [ -n "${!e}" ]; then
+			haveConfig=1
 		fi
 	done
 
-	file_env 'WORDPRESS_TABLE_PREFIX'
-	if [ "$WORDPRESS_TABLE_PREFIX" ]; then
-		set_config '$table_prefix' "$WORDPRESS_TABLE_PREFIX"
+	# linking backwards-compatibility
+	if [ -n "${!MYSQL_ENV_MYSQL_*}" ]; then
+		haveConfig=1
+		# host defaults to "mysql" below if unspecified
+		: "${WORDPRESS_DB_USER:=${MYSQL_ENV_MYSQL_USER:-root}}"
+		if [ "$WORDPRESS_DB_USER" = 'root' ]; then
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}}"
+		else
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_PASSWORD:-}}"
+		fi
+		: "${WORDPRESS_DB_NAME:=${MYSQL_ENV_MYSQL_DATABASE:-}}"
 	fi
 
-	file_env 'WORDPRESS_DEBUG'
-	if [ "$WORDPRESS_DEBUG" ]; then
-		set_config 'WP_DEBUG' 1 boolean
-	fi
+	# only touch "wp-config.php" if we have environment-supplied configuration values
+	if [ "$haveConfig" ]; then
+		: "${WORDPRESS_DB_HOST:=mysql}"
+		: "${WORDPRESS_DB_USER:=root}"
+		: "${WORDPRESS_DB_PASSWORD:=}"
+		: "${WORDPRESS_DB_NAME:=wordpress}"
 
-	TERM=dumb php -- "$WORDPRESS_DB_HOST" "$WORDPRESS_DB_USER" "$WORDPRESS_DB_PASSWORD" "$WORDPRESS_DB_NAME" <<'EOPHP'
+		# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
+		# https://github.com/docker-library/wordpress/issues/116
+		# https://github.com/WordPress/WordPress/commit/1acedc542fba2482bab88ec70d4bea4b997a92e4
+		sed -ri -e 's/\r$//' wp-config*
+
+		if [ ! -e wp-config.php ]; then
+			awk '/^\/\*.*stop editing.*\*\/$/ && c == 0 { c = 1; system("cat") } { print }' wp-config-sample.php > wp-config.php <<'EOPHP'
+// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
+// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+	$_SERVER['HTTPS'] = 'on';
+}
+
+EOPHP
+			chown www-data:www-data wp-config.php
+		fi
+
+		# see http://stackoverflow.com/a/2705678/433558
+		sed_escape_lhs() {
+			echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
+		}
+		sed_escape_rhs() {
+			echo "$@" | sed -e 's/[\/&]/\\&/g'
+		}
+		php_escape() {
+			php -r 'var_export(('$2') $argv[1]);' -- "$1"
+		}
+		set_config() {
+			key="$1"
+			value="$2"
+			var_type="${3:-string}"
+			start="(['\"])$(sed_escape_lhs "$key")\2\s*,"
+			end="\);"
+			if [ "${key:0:1}" = '$' ]; then
+				start="^(\s*)$(sed_escape_lhs "$key")\s*="
+				end=";"
+			fi
+			sed -ri -e "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
+		}
+
+		set_config 'DB_HOST' "$WORDPRESS_DB_HOST"
+		set_config 'DB_USER' "$WORDPRESS_DB_USER"
+		set_config 'DB_PASSWORD' "$WORDPRESS_DB_PASSWORD"
+		set_config 'DB_NAME' "$WORDPRESS_DB_NAME"
+
+		for unique in "${uniqueEnvs[@]}"; do
+			uniqVar="WORDPRESS_$unique"
+			if [ -n "${!uniqVar}" ]; then
+				set_config "$unique" "${!uniqVar}"
+			else
+				# if not specified, let's generate a random value
+				currentVal="$(sed -rn -e "s/define\((([\'\"])$unique\2\s*,\s*)(['\"])(.*)\3\);/\4/p" wp-config.php)"
+				if [ "$currentVal" = 'put your unique phrase here' ]; then
+					set_config "$unique" "$(head -c1m /dev/urandom | sha1sum | cut -d' ' -f1)"
+				fi
+			fi
+		done
+
+		if [ "$WORDPRESS_TABLE_PREFIX" ]; then
+			set_config '$table_prefix' "$WORDPRESS_TABLE_PREFIX"
+		fi
+
+		if [ "$WORDPRESS_DEBUG" ]; then
+			set_config 'WP_DEBUG' 1 boolean
+		fi
+
+		TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 
@@ -160,16 +177,19 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = explode(':', $argv[1], 2);
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 
 $maxTries = 10;
 do {
-	$mysql = new mysqli($host, $argv[2], $argv[3], '', $port, $socket);
+	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);
 	if ($mysql->connect_error) {
 		fwrite($stderr, "\n" . 'MySQL Connection Error: (' . $mysql->connect_errno . ') ' . $mysql->connect_error . "\n");
 		--$maxTries;
@@ -180,7 +200,7 @@ do {
 	}
 } while ($mysql->connect_error);
 
-if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_string($argv[4]) . '`')) {
+if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_string($dbName) . '`')) {
 	fwrite($stderr, "\n" . 'MySQL "CREATE DATABASE" Error: ' . $mysql->error . "\n");
 	$mysql->close();
 	exit(1);
@@ -188,6 +208,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 
 $mysql->close();
 EOPHP
+	fi
+
+	# now that we're definitely done writing configuration, let's clear out the relevant envrionment variables (so that stray "phpinfo()" calls don't leak secrets from our code)
+	for e in "${envs[@]}"; do
+		unset "$e"
+	done
 fi
 
 exec "$@"

--- a/php7.1/fpm-alpine/docker-entrypoint.sh
+++ b/php7.1/fpm-alpine/docker-entrypoint.sh
@@ -24,31 +24,14 @@ file_env() {
 }
 
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
-	file_env 'WORDPRESS_DB_HOST' 'mysql'
-	# if we're linked to MySQL and thus have credentials already, let's use them
-	file_env 'WORDPRESS_DB_USER' "${MYSQL_ENV_MYSQL_USER:-root}"
-	if [ "$WORDPRESS_DB_USER" = 'root' ]; then
-		file_env 'WORDPRESS_DB_PASSWORD' "${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}"
-	else
-		file_env 'WORDPRESS_DB_PASSWORD' "${MYSQL_ENV_MYSQL_PASSWORD:-}"
-	fi
-	file_env 'WORDPRESS_DB_NAME' "${MYSQL_ENV_MYSQL_DATABASE:-wordpress}"
-	if [ -z "$WORDPRESS_DB_PASSWORD" ]; then
-		echo >&2 'error: missing required WORDPRESS_DB_PASSWORD environment variable'
-		echo >&2 '  Did you forget to -e WORDPRESS_DB_PASSWORD=... ?'
-		echo >&2
-		echo >&2 '  (Also of interest might be WORDPRESS_DB_USER and WORDPRESS_DB_NAME.)'
-		exit 1
-	fi
-
 	if ! [ -e index.php -a -e wp-includes/version.php ]; then
-		echo >&2 "WordPress not found in $(pwd) - copying now..."
+		echo >&2 "WordPress not found in $PWD - copying now..."
 		if [ "$(ls -A)" ]; then
-			echo >&2 "WARNING: $(pwd) is not empty - press Ctrl+C now if this is an error!"
+			echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
 			( set -x; ls -A; sleep 10 )
 		fi
 		tar cf - --one-file-system -C /usr/src/wordpress . | tar xf -
-		echo >&2 "Complete! WordPress has been successfully copied to $(pwd)"
+		echo >&2 "Complete! WordPress has been successfully copied to $PWD"
 		if [ ! -e .htaccess ]; then
 			# NOTE: The "Indexes" option is disabled in the php:apache base image
 			cat > .htaccess <<-'EOF'
@@ -69,54 +52,9 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
 	# TODO handle WordPress upgrades magically in the same way, but only if wp-includes/version.php's $wp_version is less than /usr/src/wordpress/wp-includes/version.php's $wp_version
 
-	# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
-	# https://github.com/docker-library/wordpress/issues/116
-	# https://github.com/WordPress/WordPress/commit/1acedc542fba2482bab88ec70d4bea4b997a92e4
-	sed -ri -e 's/\r$//' wp-config*
-
-	if [ ! -e wp-config.php ]; then
-		awk '/^\/\*.*stop editing.*\*\/$/ && c == 0 { c = 1; system("cat") } { print }' wp-config-sample.php > wp-config.php <<'EOPHP'
-// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
-// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
-if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
-	$_SERVER['HTTPS'] = 'on';
-}
-
-EOPHP
-		chown www-data:www-data wp-config.php
-	fi
-
-	# see http://stackoverflow.com/a/2705678/433558
-	sed_escape_lhs() {
-		echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
-	}
-	sed_escape_rhs() {
-		echo "$@" | sed -e 's/[\/&]/\\&/g'
-	}
-	php_escape() {
-		php -r 'var_export(('$2') $argv[1]);' -- "$1"
-	}
-	set_config() {
-		key="$1"
-		value="$2"
-		var_type="${3:-string}"
-		start="(['\"])$(sed_escape_lhs "$key")\2\s*,"
-		end="\);"
-		if [ "${key:0:1}" = '$' ]; then
-			start="^(\s*)$(sed_escape_lhs "$key")\s*="
-			end=";"
-		fi
-		sed -ri -e "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
-	}
-
-	set_config 'DB_HOST' "$WORDPRESS_DB_HOST"
-	set_config 'DB_USER' "$WORDPRESS_DB_USER"
-	set_config 'DB_PASSWORD' "$WORDPRESS_DB_PASSWORD"
-	set_config 'DB_NAME' "$WORDPRESS_DB_NAME"
-
 	# allow any of these "Authentication Unique Keys and Salts." to be specified via
 	# environment variables with a "WORDPRESS_" prefix (ie, "WORDPRESS_AUTH_KEY")
-	UNIQUES=(
+	uniqueEnvs=(
 		AUTH_KEY
 		SECURE_AUTH_KEY
 		LOGGED_IN_KEY
@@ -126,31 +64,110 @@ EOPHP
 		LOGGED_IN_SALT
 		NONCE_SALT
 	)
-	for unique in "${UNIQUES[@]}"; do
-		uniqVar="WORDPRESS_$unique"
-		file_env "$uniqVar"
-		if [ "${!uniqVar}" ]; then
-			set_config "$unique" "${!uniqVar}"
-		else
-			# if not specified, let's generate a random value
-			current_set="$(sed -rn -e "s/define\((([\'\"])$unique\2\s*,\s*)(['\"])(.*)\3\);/\4/p" wp-config.php)"
-			if [ "$current_set" = 'put your unique phrase here' ]; then
-				set_config "$unique" "$(head -c1m /dev/urandom | sha1sum | cut -d' ' -f1)"
-			fi
+	envs=(
+		WORDPRESS_DB_HOST
+		WORDPRESS_DB_USER
+		WORDPRESS_DB_PASSWORD
+		WORDPRESS_DB_NAME
+		"${uniqueEnvs[@]/#/WORDPRESS_}"
+		WORDPRESS_TABLE_PREFIX
+		WORDPRESS_DEBUG
+	)
+	haveConfig=
+	for e in "${envs[@]}"; do
+		file_env "$e"
+		if [ -z "$haveConfig" ] && [ -n "${!e}" ]; then
+			haveConfig=1
 		fi
 	done
 
-	file_env 'WORDPRESS_TABLE_PREFIX'
-	if [ "$WORDPRESS_TABLE_PREFIX" ]; then
-		set_config '$table_prefix' "$WORDPRESS_TABLE_PREFIX"
+	# linking backwards-compatibility
+	if [ -n "${!MYSQL_ENV_MYSQL_*}" ]; then
+		haveConfig=1
+		# host defaults to "mysql" below if unspecified
+		: "${WORDPRESS_DB_USER:=${MYSQL_ENV_MYSQL_USER:-root}}"
+		if [ "$WORDPRESS_DB_USER" = 'root' ]; then
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}}"
+		else
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_PASSWORD:-}}"
+		fi
+		: "${WORDPRESS_DB_NAME:=${MYSQL_ENV_MYSQL_DATABASE:-}}"
 	fi
 
-	file_env 'WORDPRESS_DEBUG'
-	if [ "$WORDPRESS_DEBUG" ]; then
-		set_config 'WP_DEBUG' 1 boolean
-	fi
+	# only touch "wp-config.php" if we have environment-supplied configuration values
+	if [ "$haveConfig" ]; then
+		: "${WORDPRESS_DB_HOST:=mysql}"
+		: "${WORDPRESS_DB_USER:=root}"
+		: "${WORDPRESS_DB_PASSWORD:=}"
+		: "${WORDPRESS_DB_NAME:=wordpress}"
 
-	TERM=dumb php -- "$WORDPRESS_DB_HOST" "$WORDPRESS_DB_USER" "$WORDPRESS_DB_PASSWORD" "$WORDPRESS_DB_NAME" <<'EOPHP'
+		# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
+		# https://github.com/docker-library/wordpress/issues/116
+		# https://github.com/WordPress/WordPress/commit/1acedc542fba2482bab88ec70d4bea4b997a92e4
+		sed -ri -e 's/\r$//' wp-config*
+
+		if [ ! -e wp-config.php ]; then
+			awk '/^\/\*.*stop editing.*\*\/$/ && c == 0 { c = 1; system("cat") } { print }' wp-config-sample.php > wp-config.php <<'EOPHP'
+// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
+// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+	$_SERVER['HTTPS'] = 'on';
+}
+
+EOPHP
+			chown www-data:www-data wp-config.php
+		fi
+
+		# see http://stackoverflow.com/a/2705678/433558
+		sed_escape_lhs() {
+			echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
+		}
+		sed_escape_rhs() {
+			echo "$@" | sed -e 's/[\/&]/\\&/g'
+		}
+		php_escape() {
+			php -r 'var_export(('$2') $argv[1]);' -- "$1"
+		}
+		set_config() {
+			key="$1"
+			value="$2"
+			var_type="${3:-string}"
+			start="(['\"])$(sed_escape_lhs "$key")\2\s*,"
+			end="\);"
+			if [ "${key:0:1}" = '$' ]; then
+				start="^(\s*)$(sed_escape_lhs "$key")\s*="
+				end=";"
+			fi
+			sed -ri -e "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
+		}
+
+		set_config 'DB_HOST' "$WORDPRESS_DB_HOST"
+		set_config 'DB_USER' "$WORDPRESS_DB_USER"
+		set_config 'DB_PASSWORD' "$WORDPRESS_DB_PASSWORD"
+		set_config 'DB_NAME' "$WORDPRESS_DB_NAME"
+
+		for unique in "${uniqueEnvs[@]}"; do
+			uniqVar="WORDPRESS_$unique"
+			if [ -n "${!uniqVar}" ]; then
+				set_config "$unique" "${!uniqVar}"
+			else
+				# if not specified, let's generate a random value
+				currentVal="$(sed -rn -e "s/define\((([\'\"])$unique\2\s*,\s*)(['\"])(.*)\3\);/\4/p" wp-config.php)"
+				if [ "$currentVal" = 'put your unique phrase here' ]; then
+					set_config "$unique" "$(head -c1m /dev/urandom | sha1sum | cut -d' ' -f1)"
+				fi
+			fi
+		done
+
+		if [ "$WORDPRESS_TABLE_PREFIX" ]; then
+			set_config '$table_prefix' "$WORDPRESS_TABLE_PREFIX"
+		fi
+
+		if [ "$WORDPRESS_DEBUG" ]; then
+			set_config 'WP_DEBUG' 1 boolean
+		fi
+
+		TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 
@@ -160,16 +177,19 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = explode(':', $argv[1], 2);
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 
 $maxTries = 10;
 do {
-	$mysql = new mysqli($host, $argv[2], $argv[3], '', $port, $socket);
+	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);
 	if ($mysql->connect_error) {
 		fwrite($stderr, "\n" . 'MySQL Connection Error: (' . $mysql->connect_errno . ') ' . $mysql->connect_error . "\n");
 		--$maxTries;
@@ -180,7 +200,7 @@ do {
 	}
 } while ($mysql->connect_error);
 
-if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_string($argv[4]) . '`')) {
+if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_string($dbName) . '`')) {
 	fwrite($stderr, "\n" . 'MySQL "CREATE DATABASE" Error: ' . $mysql->error . "\n");
 	$mysql->close();
 	exit(1);
@@ -188,6 +208,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 
 $mysql->close();
 EOPHP
+	fi
+
+	# now that we're definitely done writing configuration, let's clear out the relevant envrionment variables (so that stray "phpinfo()" calls don't leak secrets from our code)
+	for e in "${envs[@]}"; do
+		unset "$e"
+	done
 fi
 
 exec "$@"

--- a/php7.1/fpm/docker-entrypoint.sh
+++ b/php7.1/fpm/docker-entrypoint.sh
@@ -24,31 +24,14 @@ file_env() {
 }
 
 if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
-	file_env 'WORDPRESS_DB_HOST' 'mysql'
-	# if we're linked to MySQL and thus have credentials already, let's use them
-	file_env 'WORDPRESS_DB_USER' "${MYSQL_ENV_MYSQL_USER:-root}"
-	if [ "$WORDPRESS_DB_USER" = 'root' ]; then
-		file_env 'WORDPRESS_DB_PASSWORD' "${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}"
-	else
-		file_env 'WORDPRESS_DB_PASSWORD' "${MYSQL_ENV_MYSQL_PASSWORD:-}"
-	fi
-	file_env 'WORDPRESS_DB_NAME' "${MYSQL_ENV_MYSQL_DATABASE:-wordpress}"
-	if [ -z "$WORDPRESS_DB_PASSWORD" ]; then
-		echo >&2 'error: missing required WORDPRESS_DB_PASSWORD environment variable'
-		echo >&2 '  Did you forget to -e WORDPRESS_DB_PASSWORD=... ?'
-		echo >&2
-		echo >&2 '  (Also of interest might be WORDPRESS_DB_USER and WORDPRESS_DB_NAME.)'
-		exit 1
-	fi
-
 	if ! [ -e index.php -a -e wp-includes/version.php ]; then
-		echo >&2 "WordPress not found in $(pwd) - copying now..."
+		echo >&2 "WordPress not found in $PWD - copying now..."
 		if [ "$(ls -A)" ]; then
-			echo >&2 "WARNING: $(pwd) is not empty - press Ctrl+C now if this is an error!"
+			echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
 			( set -x; ls -A; sleep 10 )
 		fi
 		tar cf - --one-file-system -C /usr/src/wordpress . | tar xf -
-		echo >&2 "Complete! WordPress has been successfully copied to $(pwd)"
+		echo >&2 "Complete! WordPress has been successfully copied to $PWD"
 		if [ ! -e .htaccess ]; then
 			# NOTE: The "Indexes" option is disabled in the php:apache base image
 			cat > .htaccess <<-'EOF'
@@ -69,54 +52,9 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
 	# TODO handle WordPress upgrades magically in the same way, but only if wp-includes/version.php's $wp_version is less than /usr/src/wordpress/wp-includes/version.php's $wp_version
 
-	# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
-	# https://github.com/docker-library/wordpress/issues/116
-	# https://github.com/WordPress/WordPress/commit/1acedc542fba2482bab88ec70d4bea4b997a92e4
-	sed -ri -e 's/\r$//' wp-config*
-
-	if [ ! -e wp-config.php ]; then
-		awk '/^\/\*.*stop editing.*\*\/$/ && c == 0 { c = 1; system("cat") } { print }' wp-config-sample.php > wp-config.php <<'EOPHP'
-// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
-// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
-if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
-	$_SERVER['HTTPS'] = 'on';
-}
-
-EOPHP
-		chown www-data:www-data wp-config.php
-	fi
-
-	# see http://stackoverflow.com/a/2705678/433558
-	sed_escape_lhs() {
-		echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
-	}
-	sed_escape_rhs() {
-		echo "$@" | sed -e 's/[\/&]/\\&/g'
-	}
-	php_escape() {
-		php -r 'var_export(('$2') $argv[1]);' -- "$1"
-	}
-	set_config() {
-		key="$1"
-		value="$2"
-		var_type="${3:-string}"
-		start="(['\"])$(sed_escape_lhs "$key")\2\s*,"
-		end="\);"
-		if [ "${key:0:1}" = '$' ]; then
-			start="^(\s*)$(sed_escape_lhs "$key")\s*="
-			end=";"
-		fi
-		sed -ri -e "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
-	}
-
-	set_config 'DB_HOST' "$WORDPRESS_DB_HOST"
-	set_config 'DB_USER' "$WORDPRESS_DB_USER"
-	set_config 'DB_PASSWORD' "$WORDPRESS_DB_PASSWORD"
-	set_config 'DB_NAME' "$WORDPRESS_DB_NAME"
-
 	# allow any of these "Authentication Unique Keys and Salts." to be specified via
 	# environment variables with a "WORDPRESS_" prefix (ie, "WORDPRESS_AUTH_KEY")
-	UNIQUES=(
+	uniqueEnvs=(
 		AUTH_KEY
 		SECURE_AUTH_KEY
 		LOGGED_IN_KEY
@@ -126,31 +64,110 @@ EOPHP
 		LOGGED_IN_SALT
 		NONCE_SALT
 	)
-	for unique in "${UNIQUES[@]}"; do
-		uniqVar="WORDPRESS_$unique"
-		file_env "$uniqVar"
-		if [ "${!uniqVar}" ]; then
-			set_config "$unique" "${!uniqVar}"
-		else
-			# if not specified, let's generate a random value
-			current_set="$(sed -rn -e "s/define\((([\'\"])$unique\2\s*,\s*)(['\"])(.*)\3\);/\4/p" wp-config.php)"
-			if [ "$current_set" = 'put your unique phrase here' ]; then
-				set_config "$unique" "$(head -c1m /dev/urandom | sha1sum | cut -d' ' -f1)"
-			fi
+	envs=(
+		WORDPRESS_DB_HOST
+		WORDPRESS_DB_USER
+		WORDPRESS_DB_PASSWORD
+		WORDPRESS_DB_NAME
+		"${uniqueEnvs[@]/#/WORDPRESS_}"
+		WORDPRESS_TABLE_PREFIX
+		WORDPRESS_DEBUG
+	)
+	haveConfig=
+	for e in "${envs[@]}"; do
+		file_env "$e"
+		if [ -z "$haveConfig" ] && [ -n "${!e}" ]; then
+			haveConfig=1
 		fi
 	done
 
-	file_env 'WORDPRESS_TABLE_PREFIX'
-	if [ "$WORDPRESS_TABLE_PREFIX" ]; then
-		set_config '$table_prefix' "$WORDPRESS_TABLE_PREFIX"
+	# linking backwards-compatibility
+	if [ -n "${!MYSQL_ENV_MYSQL_*}" ]; then
+		haveConfig=1
+		# host defaults to "mysql" below if unspecified
+		: "${WORDPRESS_DB_USER:=${MYSQL_ENV_MYSQL_USER:-root}}"
+		if [ "$WORDPRESS_DB_USER" = 'root' ]; then
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}}"
+		else
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_PASSWORD:-}}"
+		fi
+		: "${WORDPRESS_DB_NAME:=${MYSQL_ENV_MYSQL_DATABASE:-}}"
 	fi
 
-	file_env 'WORDPRESS_DEBUG'
-	if [ "$WORDPRESS_DEBUG" ]; then
-		set_config 'WP_DEBUG' 1 boolean
-	fi
+	# only touch "wp-config.php" if we have environment-supplied configuration values
+	if [ "$haveConfig" ]; then
+		: "${WORDPRESS_DB_HOST:=mysql}"
+		: "${WORDPRESS_DB_USER:=root}"
+		: "${WORDPRESS_DB_PASSWORD:=}"
+		: "${WORDPRESS_DB_NAME:=wordpress}"
 
-	TERM=dumb php -- "$WORDPRESS_DB_HOST" "$WORDPRESS_DB_USER" "$WORDPRESS_DB_PASSWORD" "$WORDPRESS_DB_NAME" <<'EOPHP'
+		# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
+		# https://github.com/docker-library/wordpress/issues/116
+		# https://github.com/WordPress/WordPress/commit/1acedc542fba2482bab88ec70d4bea4b997a92e4
+		sed -ri -e 's/\r$//' wp-config*
+
+		if [ ! -e wp-config.php ]; then
+			awk '/^\/\*.*stop editing.*\*\/$/ && c == 0 { c = 1; system("cat") } { print }' wp-config-sample.php > wp-config.php <<'EOPHP'
+// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
+// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+	$_SERVER['HTTPS'] = 'on';
+}
+
+EOPHP
+			chown www-data:www-data wp-config.php
+		fi
+
+		# see http://stackoverflow.com/a/2705678/433558
+		sed_escape_lhs() {
+			echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
+		}
+		sed_escape_rhs() {
+			echo "$@" | sed -e 's/[\/&]/\\&/g'
+		}
+		php_escape() {
+			php -r 'var_export(('$2') $argv[1]);' -- "$1"
+		}
+		set_config() {
+			key="$1"
+			value="$2"
+			var_type="${3:-string}"
+			start="(['\"])$(sed_escape_lhs "$key")\2\s*,"
+			end="\);"
+			if [ "${key:0:1}" = '$' ]; then
+				start="^(\s*)$(sed_escape_lhs "$key")\s*="
+				end=";"
+			fi
+			sed -ri -e "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
+		}
+
+		set_config 'DB_HOST' "$WORDPRESS_DB_HOST"
+		set_config 'DB_USER' "$WORDPRESS_DB_USER"
+		set_config 'DB_PASSWORD' "$WORDPRESS_DB_PASSWORD"
+		set_config 'DB_NAME' "$WORDPRESS_DB_NAME"
+
+		for unique in "${uniqueEnvs[@]}"; do
+			uniqVar="WORDPRESS_$unique"
+			if [ -n "${!uniqVar}" ]; then
+				set_config "$unique" "${!uniqVar}"
+			else
+				# if not specified, let's generate a random value
+				currentVal="$(sed -rn -e "s/define\((([\'\"])$unique\2\s*,\s*)(['\"])(.*)\3\);/\4/p" wp-config.php)"
+				if [ "$currentVal" = 'put your unique phrase here' ]; then
+					set_config "$unique" "$(head -c1m /dev/urandom | sha1sum | cut -d' ' -f1)"
+				fi
+			fi
+		done
+
+		if [ "$WORDPRESS_TABLE_PREFIX" ]; then
+			set_config '$table_prefix' "$WORDPRESS_TABLE_PREFIX"
+		fi
+
+		if [ "$WORDPRESS_DEBUG" ]; then
+			set_config 'WP_DEBUG' 1 boolean
+		fi
+
+		TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 
@@ -160,16 +177,19 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = explode(':', $argv[1], 2);
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 
 $maxTries = 10;
 do {
-	$mysql = new mysqli($host, $argv[2], $argv[3], '', $port, $socket);
+	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);
 	if ($mysql->connect_error) {
 		fwrite($stderr, "\n" . 'MySQL Connection Error: (' . $mysql->connect_errno . ') ' . $mysql->connect_error . "\n");
 		--$maxTries;
@@ -180,7 +200,7 @@ do {
 	}
 } while ($mysql->connect_error);
 
-if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_string($argv[4]) . '`')) {
+if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_string($dbName) . '`')) {
 	fwrite($stderr, "\n" . 'MySQL "CREATE DATABASE" Error: ' . $mysql->error . "\n");
 	$mysql->close();
 	exit(1);
@@ -188,6 +208,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 
 $mysql->close();
 EOPHP
+	fi
+
+	# now that we're definitely done writing configuration, let's clear out the relevant envrionment variables (so that stray "phpinfo()" calls don't leak secrets from our code)
+	for e in "${envs[@]}"; do
+		unset "$e"
+	done
 fi
 
 exec "$@"


### PR DESCRIPTION
Also, unset "secret" environment variables before starting Apache/FPM to ensure that a stray `phpinfo()` doesn't include secrets from our code. (cc @thaJeztah)

Fixes #135

It's worth noting that WordPress now will also detect the absence of `wp-config.php`, and have a short pre-wizard to configure it, so all configuration can be done directly in the browser (which this PR enables by skipping the `wp-config.php` behavior if we don't have one of the special `WORDPRESS_...` vars, or an explicitly linked `mysql` container sharing environment variables with us).