### PR TITLE
move to generic 'libpng-dev' package

### DIFF
--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -6,7 +6,7 @@ RUN set -ex; \
 	apt-get update; \
 	apt-get install -y \
 		libjpeg-dev \
-		libpng12-dev \
+		libpng-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/php5.6/apache/Dockerfile
+++ b/php5.6/apache/Dockerfile
@@ -6,7 +6,7 @@ RUN set -ex; \
 	apt-get update; \
 	apt-get install -y \
 		libjpeg-dev \
-		libpng12-dev \
+		libpng-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/php5.6/fpm/Dockerfile
+++ b/php5.6/fpm/Dockerfile
@@ -6,7 +6,7 @@ RUN set -ex; \
 	apt-get update; \
 	apt-get install -y \
 		libjpeg-dev \
-		libpng12-dev \
+		libpng-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/php7.0/apache/Dockerfile
+++ b/php7.0/apache/Dockerfile
@@ -6,7 +6,7 @@ RUN set -ex; \
 	apt-get update; \
 	apt-get install -y \
 		libjpeg-dev \
-		libpng12-dev \
+		libpng-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/php7.0/fpm/Dockerfile
+++ b/php7.0/fpm/Dockerfile
@@ -6,7 +6,7 @@ RUN set -ex; \
 	apt-get update; \
 	apt-get install -y \
 		libjpeg-dev \
-		libpng12-dev \
+		libpng-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/php7.1/apache/Dockerfile
+++ b/php7.1/apache/Dockerfile
@@ -6,7 +6,7 @@ RUN set -ex; \
 	apt-get update; \
 	apt-get install -y \
 		libjpeg-dev \
-		libpng12-dev \
+		libpng-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/php7.1/fpm/Dockerfile
+++ b/php7.1/fpm/Dockerfile
@@ -6,7 +6,7 @@ RUN set -ex; \
 	apt-get update; \
 	apt-get install -y \
 		libjpeg-dev \
-		libpng12-dev \
+		libpng-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\


### PR DESCRIPTION
When referring to a specific version like libpng12-dev, dist-upgrading
would fail. Current stable (stretch) provides libpng16-dev. Using the
generic name in templates makes more sense.