### PR TITLE
Add support for newlines in MySQL passwords

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -126,7 +126,11 @@ EOPHP
 			echo "$@" | sed -e 's/[\/&]/\\&/g'
 		}
 		php_escape() {
-			php -r 'var_export(('$2') $argv[1]);' -- "$1"
+			local escaped="$(php -r 'var_export(('"$2"') $argv[1]);' -- "$1")"
+			if [ "$2" = 'string' ] && [ "${escaped:0:1}" = "'" ]; then
+				escaped="${escaped//$'\n'/"' + \"\\n\" + '"}"
+			fi
+			echo "$escaped"
 		}
 		set_config() {
 			key="$1"

--- a/php5.6/apache/docker-entrypoint.sh
+++ b/php5.6/apache/docker-entrypoint.sh
@@ -126,7 +126,11 @@ EOPHP
 			echo "$@" | sed -e 's/[\/&]/\\&/g'
 		}
 		php_escape() {
-			php -r 'var_export(('$2') $argv[1]);' -- "$1"
+			local escaped="$(php -r 'var_export(('"$2"') $argv[1]);' -- "$1")"
+			if [ "$2" = 'string' ] && [ "${escaped:0:1}" = "'" ]; then
+				escaped="${escaped//$'\n'/"' + \"\\n\" + '"}"
+			fi
+			echo "$escaped"
 		}
 		set_config() {
 			key="$1"

--- a/php5.6/fpm-alpine/docker-entrypoint.sh
+++ b/php5.6/fpm-alpine/docker-entrypoint.sh
@@ -126,7 +126,11 @@ EOPHP
 			echo "$@" | sed -e 's/[\/&]/\\&/g'
 		}
 		php_escape() {
-			php -r 'var_export(('$2') $argv[1]);' -- "$1"
+			local escaped="$(php -r 'var_export(('"$2"') $argv[1]);' -- "$1")"
+			if [ "$2" = 'string' ] && [ "${escaped:0:1}" = "'" ]; then
+				escaped="${escaped//$'\n'/"' + \"\\n\" + '"}"
+			fi
+			echo "$escaped"
 		}
 		set_config() {
 			key="$1"

--- a/php5.6/fpm/docker-entrypoint.sh
+++ b/php5.6/fpm/docker-entrypoint.sh
@@ -126,7 +126,11 @@ EOPHP
 			echo "$@" | sed -e 's/[\/&]/\\&/g'
 		}
 		php_escape() {
-			php -r 'var_export(('$2') $argv[1]);' -- "$1"
+			local escaped="$(php -r 'var_export(('"$2"') $argv[1]);' -- "$1")"
+			if [ "$2" = 'string' ] && [ "${escaped:0:1}" = "'" ]; then
+				escaped="${escaped//$'\n'/"' + \"\\n\" + '"}"
+			fi
+			echo "$escaped"
 		}
 		set_config() {
 			key="$1"

--- a/php7.0/apache/docker-entrypoint.sh
+++ b/php7.0/apache/docker-entrypoint.sh
@@ -126,7 +126,11 @@ EOPHP
 			echo "$@" | sed -e 's/[\/&]/\\&/g'
 		}
 		php_escape() {
-			php -r 'var_export(('$2') $argv[1]);' -- "$1"
+			local escaped="$(php -r 'var_export(('"$2"') $argv[1]);' -- "$1")"
+			if [ "$2" = 'string' ] && [ "${escaped:0:1}" = "'" ]; then
+				escaped="${escaped//$'\n'/"' + \"\\n\" + '"}"
+			fi
+			echo "$escaped"
 		}
 		set_config() {
 			key="$1"

--- a/php7.0/fpm-alpine/docker-entrypoint.sh
+++ b/php7.0/fpm-alpine/docker-entrypoint.sh
@@ -126,7 +126,11 @@ EOPHP
 			echo "$@" | sed -e 's/[\/&]/\\&/g'
 		}
 		php_escape() {
-			php -r 'var_export(('$2') $argv[1]);' -- "$1"
+			local escaped="$(php -r 'var_export(('"$2"') $argv[1]);' -- "$1")"
+			if [ "$2" = 'string' ] && [ "${escaped:0:1}" = "'" ]; then
+				escaped="${escaped//$'\n'/"' + \"\\n\" + '"}"
+			fi
+			echo "$escaped"
 		}
 		set_config() {
 			key="$1"

--- a/php7.0/fpm/docker-entrypoint.sh
+++ b/php7.0/fpm/docker-entrypoint.sh
@@ -126,7 +126,11 @@ EOPHP
 			echo "$@" | sed -e 's/[\/&]/\\&/g'
 		}
 		php_escape() {
-			php -r 'var_export(('$2') $argv[1]);' -- "$1"
+			local escaped="$(php -r 'var_export(('"$2"') $argv[1]);' -- "$1")"
+			if [ "$2" = 'string' ] && [ "${escaped:0:1}" = "'" ]; then
+				escaped="${escaped//$'\n'/"' + \"\\n\" + '"}"
+			fi
+			echo "$escaped"
 		}
 		set_config() {
 			key="$1"

--- a/php7.1/apache/docker-entrypoint.sh
+++ b/php7.1/apache/docker-entrypoint.sh
@@ -126,7 +126,11 @@ EOPHP
 			echo "$@" | sed -e 's/[\/&]/\\&/g'
 		}
 		php_escape() {
-			php -r 'var_export(('$2') $argv[1]);' -- "$1"
+			local escaped="$(php -r 'var_export(('"$2"') $argv[1]);' -- "$1")"
+			if [ "$2" = 'string' ] && [ "${escaped:0:1}" = "'" ]; then
+				escaped="${escaped//$'\n'/"' + \"\\n\" + '"}"
+			fi
+			echo "$escaped"
 		}
 		set_config() {
 			key="$1"

--- a/php7.1/fpm-alpine/docker-entrypoint.sh
+++ b/php7.1/fpm-alpine/docker-entrypoint.sh
@@ -126,7 +126,11 @@ EOPHP
 			echo "$@" | sed -e 's/[\/&]/\\&/g'
 		}
 		php_escape() {
-			php -r 'var_export(('$2') $argv[1]);' -- "$1"
+			local escaped="$(php -r 'var_export(('"$2"') $argv[1]);' -- "$1")"
+			if [ "$2" = 'string' ] && [ "${escaped:0:1}" = "'" ]; then
+				escaped="${escaped//$'\n'/"' + \"\\n\" + '"}"
+			fi
+			echo "$escaped"
 		}
 		set_config() {
 			key="$1"

--- a/php7.1/fpm/docker-entrypoint.sh
+++ b/php7.1/fpm/docker-entrypoint.sh
@@ -126,7 +126,11 @@ EOPHP
 			echo "$@" | sed -e 's/[\/&]/\\&/g'
 		}
 		php_escape() {
-			php -r 'var_export(('$2') $argv[1]);' -- "$1"
+			local escaped="$(php -r 'var_export(('"$2"') $argv[1]);' -- "$1")"
+			if [ "$2" = 'string' ] && [ "${escaped:0:1}" = "'" ]; then
+				escaped="${escaped//$'\n'/"' + \"\\n\" + '"}"
+			fi
+			echo "$escaped"
 		}
 		set_config() {
 			key="$1"


### PR DESCRIPTION
Closes #233

I verified this by doing the following:
```console
$ docker run -dit --name mysql -e MYSQL_ROOT_PASSWORD=$'\na\nb\nc\n' mysql:5.7
fdc19dd20c8a203c5614272d760c557c49ec3fff8646fe555043862738f46b4f
$ docker exec -it mysql mysql -uroot -p$'\na\nb\nc\n' -e 'SELECT 1'
mysql: [Warning] Using a password on the command line interface can be insecure.
+---+
| 1 |
+---+
| 1 |
+---+
$ docker run -it --rm -e WORDPRESS_DB_PASSWORD=$'\na\nb\nc\n' --name wordpress --link mysql:mysql ee9b41f73de3
...
```

(Where `ee9b41f73de3` is an image built with this change.)

Then I hit my new `wordpress` container from the browser and went through the setup process.

Without this change, the `WORDPRESS_DB_PASSWORD` variable having newlines in it causes `sed: -e expression #1, char 80: unterminated `s' command` (as in #233).