### PR TITLE
Remove the *-dev deps and only keep the necessary lib* packages

### DIFF
--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -3,23 +3,29 @@ FROM php:%%PHP_VERSION%%-%%VARIANT%%
 # install the PHP extensions we need
 RUN set -ex; \
 	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
 	apt-get update; \
-	buildDeps=" \
+	apt-get install -y --no-install-recommends \
 		libjpeg-dev \
 		libpng-dev \
-	"; \
-	apt-get install -y \
-		$buildDeps \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
 	docker-php-ext-install gd mysqli opcache; \
 	\
-	apt-mark manual \
-		libjpeg62-turbo \
-	; \
-	apt-mark manual libpng12-0 || apt-mark manual libpng16-16; \
-	apt-get purge -y --auto-remove $buildDeps; \
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -4,15 +4,23 @@ FROM php:%%PHP_VERSION%%-%%VARIANT%%
 RUN set -ex; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	buildDeps=" \
 		libjpeg-dev \
 		libpng-dev \
+	"; \
+	apt-get install -y \
+		$buildDeps \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
-	docker-php-ext-install gd mysqli opcache
-# TODO consider removing the *-dev deps and only keeping the necessary lib* packages
+	docker-php-ext-install gd mysqli opcache; \
+	\
+	apt-mark manual \
+		libjpeg62-turbo \
+	; \
+	apt-mark manual libpng12-0 || apt-mark manual libpng16-16; \
+	apt-get purge -y --auto-remove $buildDeps; \
+	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php

--- a/php5.6/apache/Dockerfile
+++ b/php5.6/apache/Dockerfile
@@ -3,23 +3,29 @@ FROM php:5.6-apache
 # install the PHP extensions we need
 RUN set -ex; \
 	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
 	apt-get update; \
-	buildDeps=" \
+	apt-get install -y --no-install-recommends \
 		libjpeg-dev \
 		libpng-dev \
-	"; \
-	apt-get install -y \
-		$buildDeps \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
 	docker-php-ext-install gd mysqli opcache; \
 	\
-	apt-mark manual \
-		libjpeg62-turbo \
-	; \
-	apt-mark manual libpng12-0 || apt-mark manual libpng16-16; \
-	apt-get purge -y --auto-remove $buildDeps; \
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings

--- a/php5.6/apache/Dockerfile
+++ b/php5.6/apache/Dockerfile
@@ -4,15 +4,23 @@ FROM php:5.6-apache
 RUN set -ex; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	buildDeps=" \
 		libjpeg-dev \
 		libpng-dev \
+	"; \
+	apt-get install -y \
+		$buildDeps \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
-	docker-php-ext-install gd mysqli opcache
-# TODO consider removing the *-dev deps and only keeping the necessary lib* packages
+	docker-php-ext-install gd mysqli opcache; \
+	\
+	apt-mark manual \
+		libjpeg62-turbo \
+	; \
+	apt-mark manual libpng12-0 || apt-mark manual libpng16-16; \
+	apt-get purge -y --auto-remove $buildDeps; \
+	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php

--- a/php5.6/fpm/Dockerfile
+++ b/php5.6/fpm/Dockerfile
@@ -4,15 +4,23 @@ FROM php:5.6-fpm
 RUN set -ex; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	buildDeps=" \
 		libjpeg-dev \
 		libpng-dev \
+	"; \
+	apt-get install -y \
+		$buildDeps \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
-	docker-php-ext-install gd mysqli opcache
-# TODO consider removing the *-dev deps and only keeping the necessary lib* packages
+	docker-php-ext-install gd mysqli opcache; \
+	\
+	apt-mark manual \
+		libjpeg62-turbo \
+	; \
+	apt-mark manual libpng12-0 || apt-mark manual libpng16-16; \
+	apt-get purge -y --auto-remove $buildDeps; \
+	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php

--- a/php5.6/fpm/Dockerfile
+++ b/php5.6/fpm/Dockerfile
@@ -3,23 +3,29 @@ FROM php:5.6-fpm
 # install the PHP extensions we need
 RUN set -ex; \
 	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
 	apt-get update; \
-	buildDeps=" \
+	apt-get install -y --no-install-recommends \
 		libjpeg-dev \
 		libpng-dev \
-	"; \
-	apt-get install -y \
-		$buildDeps \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
 	docker-php-ext-install gd mysqli opcache; \
 	\
-	apt-mark manual \
-		libjpeg62-turbo \
-	; \
-	apt-mark manual libpng12-0 || apt-mark manual libpng16-16; \
-	apt-get purge -y --auto-remove $buildDeps; \
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings

--- a/php7.0/apache/Dockerfile
+++ b/php7.0/apache/Dockerfile
@@ -4,15 +4,23 @@ FROM php:7.0-apache
 RUN set -ex; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	buildDeps=" \
 		libjpeg-dev \
 		libpng-dev \
+	"; \
+	apt-get install -y \
+		$buildDeps \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
-	docker-php-ext-install gd mysqli opcache
-# TODO consider removing the *-dev deps and only keeping the necessary lib* packages
+	docker-php-ext-install gd mysqli opcache; \
+	\
+	apt-mark manual \
+		libjpeg62-turbo \
+	; \
+	apt-mark manual libpng12-0 || apt-mark manual libpng16-16; \
+	apt-get purge -y --auto-remove $buildDeps; \
+	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php

--- a/php7.0/apache/Dockerfile
+++ b/php7.0/apache/Dockerfile
@@ -3,23 +3,29 @@ FROM php:7.0-apache
 # install the PHP extensions we need
 RUN set -ex; \
 	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
 	apt-get update; \
-	buildDeps=" \
+	apt-get install -y --no-install-recommends \
 		libjpeg-dev \
 		libpng-dev \
-	"; \
-	apt-get install -y \
-		$buildDeps \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
 	docker-php-ext-install gd mysqli opcache; \
 	\
-	apt-mark manual \
-		libjpeg62-turbo \
-	; \
-	apt-mark manual libpng12-0 || apt-mark manual libpng16-16; \
-	apt-get purge -y --auto-remove $buildDeps; \
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings

--- a/php7.0/fpm/Dockerfile
+++ b/php7.0/fpm/Dockerfile
@@ -4,15 +4,23 @@ FROM php:7.0-fpm
 RUN set -ex; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	buildDeps=" \
 		libjpeg-dev \
 		libpng-dev \
+	"; \
+	apt-get install -y \
+		$buildDeps \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
-	docker-php-ext-install gd mysqli opcache
-# TODO consider removing the *-dev deps and only keeping the necessary lib* packages
+	docker-php-ext-install gd mysqli opcache; \
+	\
+	apt-mark manual \
+		libjpeg62-turbo \
+	; \
+	apt-mark manual libpng12-0 || apt-mark manual libpng16-16; \
+	apt-get purge -y --auto-remove $buildDeps; \
+	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php

--- a/php7.0/fpm/Dockerfile
+++ b/php7.0/fpm/Dockerfile
@@ -3,23 +3,29 @@ FROM php:7.0-fpm
 # install the PHP extensions we need
 RUN set -ex; \
 	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
 	apt-get update; \
-	buildDeps=" \
+	apt-get install -y --no-install-recommends \
 		libjpeg-dev \
 		libpng-dev \
-	"; \
-	apt-get install -y \
-		$buildDeps \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
 	docker-php-ext-install gd mysqli opcache; \
 	\
-	apt-mark manual \
-		libjpeg62-turbo \
-	; \
-	apt-mark manual libpng12-0 || apt-mark manual libpng16-16; \
-	apt-get purge -y --auto-remove $buildDeps; \
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings

--- a/php7.1/apache/Dockerfile
+++ b/php7.1/apache/Dockerfile
@@ -3,23 +3,29 @@ FROM php:7.1-apache
 # install the PHP extensions we need
 RUN set -ex; \
 	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
 	apt-get update; \
-	buildDeps=" \
+	apt-get install -y --no-install-recommends \
 		libjpeg-dev \
 		libpng-dev \
-	"; \
-	apt-get install -y \
-		$buildDeps \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
 	docker-php-ext-install gd mysqli opcache; \
 	\
-	apt-mark manual \
-		libjpeg62-turbo \
-	; \
-	apt-mark manual libpng12-0 || apt-mark manual libpng16-16; \
-	apt-get purge -y --auto-remove $buildDeps; \
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings

--- a/php7.1/apache/Dockerfile
+++ b/php7.1/apache/Dockerfile
@@ -4,15 +4,23 @@ FROM php:7.1-apache
 RUN set -ex; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	buildDeps=" \
 		libjpeg-dev \
 		libpng-dev \
+	"; \
+	apt-get install -y \
+		$buildDeps \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
-	docker-php-ext-install gd mysqli opcache
-# TODO consider removing the *-dev deps and only keeping the necessary lib* packages
+	docker-php-ext-install gd mysqli opcache; \
+	\
+	apt-mark manual \
+		libjpeg62-turbo \
+	; \
+	apt-mark manual libpng12-0 || apt-mark manual libpng16-16; \
+	apt-get purge -y --auto-remove $buildDeps; \
+	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php

--- a/php7.1/fpm/Dockerfile
+++ b/php7.1/fpm/Dockerfile
@@ -4,15 +4,23 @@ FROM php:7.1-fpm
 RUN set -ex; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	buildDeps=" \
 		libjpeg-dev \
 		libpng-dev \
+	"; \
+	apt-get install -y \
+		$buildDeps \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
-	docker-php-ext-install gd mysqli opcache
-# TODO consider removing the *-dev deps and only keeping the necessary lib* packages
+	docker-php-ext-install gd mysqli opcache; \
+	\
+	apt-mark manual \
+		libjpeg62-turbo \
+	; \
+	apt-mark manual libpng12-0 || apt-mark manual libpng16-16; \
+	apt-get purge -y --auto-remove $buildDeps; \
+	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php

--- a/php7.1/fpm/Dockerfile
+++ b/php7.1/fpm/Dockerfile
@@ -3,23 +3,29 @@ FROM php:7.1-fpm
 # install the PHP extensions we need
 RUN set -ex; \
 	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
 	apt-get update; \
-	buildDeps=" \
+	apt-get install -y --no-install-recommends \
 		libjpeg-dev \
 		libpng-dev \
-	"; \
-	apt-get install -y \
-		$buildDeps \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
 	docker-php-ext-install gd mysqli opcache; \
 	\
-	apt-mark manual \
-		libjpeg62-turbo \
-	; \
-	apt-mark manual libpng12-0 || apt-mark manual libpng16-16; \
-	apt-get purge -y --auto-remove $buildDeps; \
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings

--- a/php7.2/apache/Dockerfile
+++ b/php7.2/apache/Dockerfile
@@ -3,23 +3,29 @@ FROM php:7.2-apache
 # install the PHP extensions we need
 RUN set -ex; \
 	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
 	apt-get update; \
-	buildDeps=" \
+	apt-get install -y --no-install-recommends \
 		libjpeg-dev \
 		libpng-dev \
-	"; \
-	apt-get install -y \
-		$buildDeps \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
 	docker-php-ext-install gd mysqli opcache; \
 	\
-	apt-mark manual \
-		libjpeg62-turbo \
-	; \
-	apt-mark manual libpng12-0 || apt-mark manual libpng16-16; \
-	apt-get purge -y --auto-remove $buildDeps; \
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings

--- a/php7.2/apache/Dockerfile
+++ b/php7.2/apache/Dockerfile
@@ -4,15 +4,23 @@ FROM php:7.2-apache
 RUN set -ex; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	buildDeps=" \
 		libjpeg-dev \
 		libpng-dev \
+	"; \
+	apt-get install -y \
+		$buildDeps \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
-	docker-php-ext-install gd mysqli opcache
-# TODO consider removing the *-dev deps and only keeping the necessary lib* packages
+	docker-php-ext-install gd mysqli opcache; \
+	\
+	apt-mark manual \
+		libjpeg62-turbo \
+	; \
+	apt-mark manual libpng12-0 || apt-mark manual libpng16-16; \
+	apt-get purge -y --auto-remove $buildDeps; \
+	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php

--- a/php7.2/fpm/Dockerfile
+++ b/php7.2/fpm/Dockerfile
@@ -4,15 +4,23 @@ FROM php:7.2-fpm
 RUN set -ex; \
 	\
 	apt-get update; \
-	apt-get install -y \
+	buildDeps=" \
 		libjpeg-dev \
 		libpng-dev \
+	"; \
+	apt-get install -y \
+		$buildDeps \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
-	docker-php-ext-install gd mysqli opcache
-# TODO consider removing the *-dev deps and only keeping the necessary lib* packages
+	docker-php-ext-install gd mysqli opcache; \
+	\
+	apt-mark manual \
+		libjpeg62-turbo \
+	; \
+	apt-mark manual libpng12-0 || apt-mark manual libpng16-16; \
+	apt-get purge -y --auto-remove $buildDeps; \
+	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php

--- a/php7.2/fpm/Dockerfile
+++ b/php7.2/fpm/Dockerfile
@@ -3,23 +3,29 @@ FROM php:7.2-fpm
 # install the PHP extensions we need
 RUN set -ex; \
 	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
 	apt-get update; \
-	buildDeps=" \
+	apt-get install -y --no-install-recommends \
 		libjpeg-dev \
 		libpng-dev \
-	"; \
-	apt-get install -y \
-		$buildDeps \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
 	docker-php-ext-install gd mysqli opcache; \
 	\
-	apt-mark manual \
-		libjpeg62-turbo \
-	; \
-	apt-mark manual libpng12-0 || apt-mark manual libpng16-16; \
-	apt-get purge -y --auto-remove $buildDeps; \
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*
 
 # set recommended PHP.ini settings


### PR DESCRIPTION
I didn't found an open discussion about this `TODO`, so I'm just providing this PR to get rid of it. This seems to be already done for Alpine variants.
The `||` was the simplest way I found to deal with the different libpng package names in Debain.