### PR TITLE
Try more keyservers to fix unstable Travis builds

### DIFF
--- a/Dockerfile-cli.template
+++ b/Dockerfile-cli.template
@@ -60,7 +60,9 @@ RUN set -ex; \
 	curl -o /usr/local/bin/wp.gpg -fSL "https://github.com/wp-cli/wp-cli/releases/download/v${WORDPRESS_CLI_VERSION}/wp-cli-${WORDPRESS_CLI_VERSION}.phar.gpg"; \
 	\
 	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$WORDPRESS_CLI_GPG_KEY"; \
+	( gpg --keyserver Zpool.sks-keyservers.net --recv-keys "$WORDPRESS_CLI_GPG_KEY" \
+    || gpg --keyserver pgp.mit.edu --recv-keys "$WORDPRESS_CLI_GPG_KEY" \
+    || gpg --keyserver keyserver.pgp.com --recv-keys "$WORDPRESS_CLI_GPG_KEY" ); \
 	gpg --batch --decrypt --output /usr/local/bin/wp /usr/local/bin/wp.gpg; \
 	rm -rf "$GNUPGHOME" /usr/local/bin/wp.gpg; \
 	\

--- a/php5.6/cli/Dockerfile
+++ b/php5.6/cli/Dockerfile
@@ -60,7 +60,9 @@ RUN set -ex; \
 	curl -o /usr/local/bin/wp.gpg -fSL "https://github.com/wp-cli/wp-cli/releases/download/v${WORDPRESS_CLI_VERSION}/wp-cli-${WORDPRESS_CLI_VERSION}.phar.gpg"; \
 	\
 	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$WORDPRESS_CLI_GPG_KEY"; \
+	( gpg --keyserver Zpool.sks-keyservers.net --recv-keys "$WORDPRESS_CLI_GPG_KEY" \
+    || gpg --keyserver pgp.mit.edu --recv-keys "$WORDPRESS_CLI_GPG_KEY" \
+    || gpg --keyserver keyserver.pgp.com --recv-keys "$WORDPRESS_CLI_GPG_KEY" ); \
 	gpg --batch --decrypt --output /usr/local/bin/wp /usr/local/bin/wp.gpg; \
 	rm -rf "$GNUPGHOME" /usr/local/bin/wp.gpg; \
 	\

--- a/php7.0/cli/Dockerfile
+++ b/php7.0/cli/Dockerfile
@@ -60,7 +60,9 @@ RUN set -ex; \
 	curl -o /usr/local/bin/wp.gpg -fSL "https://github.com/wp-cli/wp-cli/releases/download/v${WORDPRESS_CLI_VERSION}/wp-cli-${WORDPRESS_CLI_VERSION}.phar.gpg"; \
 	\
 	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$WORDPRESS_CLI_GPG_KEY"; \
+	( gpg --keyserver Zpool.sks-keyservers.net --recv-keys "$WORDPRESS_CLI_GPG_KEY" \
+    || gpg --keyserver pgp.mit.edu --recv-keys "$WORDPRESS_CLI_GPG_KEY" \
+    || gpg --keyserver keyserver.pgp.com --recv-keys "$WORDPRESS_CLI_GPG_KEY" ); \
 	gpg --batch --decrypt --output /usr/local/bin/wp /usr/local/bin/wp.gpg; \
 	rm -rf "$GNUPGHOME" /usr/local/bin/wp.gpg; \
 	\

--- a/php7.1/cli/Dockerfile
+++ b/php7.1/cli/Dockerfile
@@ -60,7 +60,9 @@ RUN set -ex; \
 	curl -o /usr/local/bin/wp.gpg -fSL "https://github.com/wp-cli/wp-cli/releases/download/v${WORDPRESS_CLI_VERSION}/wp-cli-${WORDPRESS_CLI_VERSION}.phar.gpg"; \
 	\
 	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$WORDPRESS_CLI_GPG_KEY"; \
+	( gpg --keyserver Zpool.sks-keyservers.net --recv-keys "$WORDPRESS_CLI_GPG_KEY" \
+    || gpg --keyserver pgp.mit.edu --recv-keys "$WORDPRESS_CLI_GPG_KEY" \
+    || gpg --keyserver keyserver.pgp.com --recv-keys "$WORDPRESS_CLI_GPG_KEY" ); \
 	gpg --batch --decrypt --output /usr/local/bin/wp /usr/local/bin/wp.gpg; \
 	rm -rf "$GNUPGHOME" /usr/local/bin/wp.gpg; \
 	\

--- a/php7.2/cli/Dockerfile
+++ b/php7.2/cli/Dockerfile
@@ -60,7 +60,9 @@ RUN set -ex; \
 	curl -o /usr/local/bin/wp.gpg -fSL "https://github.com/wp-cli/wp-cli/releases/download/v${WORDPRESS_CLI_VERSION}/wp-cli-${WORDPRESS_CLI_VERSION}.phar.gpg"; \
 	\
 	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$WORDPRESS_CLI_GPG_KEY"; \
+	( gpg --keyserver Zpool.sks-keyservers.net --recv-keys "$WORDPRESS_CLI_GPG_KEY" \
+    || gpg --keyserver pgp.mit.edu --recv-keys "$WORDPRESS_CLI_GPG_KEY" \
+    || gpg --keyserver keyserver.pgp.com --recv-keys "$WORDPRESS_CLI_GPG_KEY" ); \
 	gpg --batch --decrypt --output /usr/local/bin/wp /usr/local/bin/wp.gpg; \
 	rm -rf "$GNUPGHOME" /usr/local/bin/wp.gpg; \
 	\


### PR DESCRIPTION
Travis jobs to build the CI images are failing regularly because `ha.pool.sks-keyservers.net` seems unavailable (https://travis-ci.org/docker-library/wordpress/jobs/338804185):

```
+ gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 3B9191625F3B1F1BF5DD3B47673A02042F6B6B7F
gpg: keybox '/tmp/tmp.IcLNCf/pubring.kbx' created
gpg: keyserver receive failed: Address not available
```

I modified the Dockerfiles to try three different pools in an attempt to mitigate the problem. 
