### PR TITLE
Update Dockerfile | Adding  zlib1g-dev

### DIFF
--- a/php7.2/apache/Dockerfile
+++ b/php7.2/apache/Dockerfile
@@ -9,6 +9,7 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		libjpeg-dev \
 		libpng-dev \
+                zlib1g-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \


### PR DESCRIPTION
Php zip module was failing due to the lack of zlib1g-dev 