### PR TITLE
Add bash to wp-cli for `wp shell`

### DIFF
--- a/Dockerfile-cli.template
+++ b/Dockerfile-cli.template
@@ -33,6 +33,8 @@ RUN { \
 
 # install wp-cli dependencies
 RUN apk add --no-cache \
+# bash is needed for 'wp shell': https://github.com/wp-cli/shell-command/blob/b8dafcc2a2eba5732fdee70be077675a302848e9/src/WP_CLI/REPL.php#L104
+		bash \
 		less \
 		mysql-client
 

--- a/php5.6/cli/Dockerfile
+++ b/php5.6/cli/Dockerfile
@@ -33,6 +33,8 @@ RUN { \
 
 # install wp-cli dependencies
 RUN apk add --no-cache \
+# bash is needed for 'wp shell': https://github.com/wp-cli/shell-command/blob/b8dafcc2a2eba5732fdee70be077675a302848e9/src/WP_CLI/REPL.php#L104
+		bash \
 		less \
 		mysql-client
 

--- a/php7.0/cli/Dockerfile
+++ b/php7.0/cli/Dockerfile
@@ -33,6 +33,8 @@ RUN { \
 
 # install wp-cli dependencies
 RUN apk add --no-cache \
+# bash is needed for 'wp shell': https://github.com/wp-cli/shell-command/blob/b8dafcc2a2eba5732fdee70be077675a302848e9/src/WP_CLI/REPL.php#L104
+		bash \
 		less \
 		mysql-client
 

--- a/php7.1/cli/Dockerfile
+++ b/php7.1/cli/Dockerfile
@@ -33,6 +33,8 @@ RUN { \
 
 # install wp-cli dependencies
 RUN apk add --no-cache \
+# bash is needed for 'wp shell': https://github.com/wp-cli/shell-command/blob/b8dafcc2a2eba5732fdee70be077675a302848e9/src/WP_CLI/REPL.php#L104
+		bash \
 		less \
 		mysql-client
 

--- a/php7.2/cli/Dockerfile
+++ b/php7.2/cli/Dockerfile
@@ -33,6 +33,8 @@ RUN { \
 
 # install wp-cli dependencies
 RUN apk add --no-cache \
+# bash is needed for 'wp shell': https://github.com/wp-cli/shell-command/blob/b8dafcc2a2eba5732fdee70be077675a302848e9/src/WP_CLI/REPL.php#L104
+		bash \
 		less \
 		mysql-client
 


### PR DESCRIPTION
Fixes #334.

wp-cli assumes `/bin/bash` is available [here](https://github.com/wp-cli/shell-command/blob/b8dafcc2a2eba5732fdee70be077675a302848e9/src/WP_CLI/REPL.php#L104).