### PR TITLE
Proposal: Ship production ready image by default

### DIFF
--- a/php7.2/fpm-alpine/Dockerfile
+++ b/php7.2/fpm-alpine/Dockerfile
@@ -29,7 +29,7 @@ RUN set -ex; \
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php
-RUN { \
+RUN { mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini; \
 		echo 'opcache.memory_consumption=128'; \
 		echo 'opcache.interned_strings_buffer=8'; \
 		echo 'opcache.max_accelerated_files=4000'; \


### PR DESCRIPTION
## Describe the problem

This is a follow up to https://github.com/docker-library/php/issues/692.

The PHP image `wordpress:fpm-alpine` and I think all other image variants come with the setting `display_errors = On` by default.

This is a bit problematic, because this setting can expose the mysqli connection credentials from a Wordpress site by displaying an error with all connection details if the database is not reachable.

## What is the desired behaviour?

I expect the Wordpress image to ship the `php.ini-production` config in order to be **secure by default** and production ready.

The official production config sets `display_errors` to `Off`: https://github.com/php/php-src/blob/php-7.2.8/php.ini-production#L477

## Describe your proposed solution

This is an incomplete PR (just to show an example solution on one of the image variants).

The problem with this solution: shipping the production config by default is a **breaking change**, since shipping no config at all is very different from shipping the production config.

Another solution would be to add some documentation on this issue, like done in https://github.com/docker-library/docs/pull/1290.

I would be happy to hear your opinion on this!

