### PR TITLE
Adding support to curl enabling themes/plugins installation

### DIFF
--- a/php7.2/apache/Dockerfile
+++ b/php7.2/apache/Dockerfile
@@ -9,10 +9,12 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		libjpeg-dev \
 		libpng-dev \
+		libcurl3 \
+    		libcurl4-openssl-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
-	docker-php-ext-install gd mysqli opcache zip; \
+	docker-php-ext-install gd mysqli opcache zip curl mbstring; \
 	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \


### PR DESCRIPTION
This solves the problem for wordpress to download themes/plugins without asking for ftp/ftps credentials

example docker-compose.yml

```yml
version: '3.7'

services:
   mysql:
     image: mysql:5.7
     volumes:
       - db_data:/var/lib/mysql
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: somewordpress
       MYSQL_DATABASE: wordpress
       MYSQL_USER: wordpress
       MYSQL_PASSWORD: wordpress

   wordpress:
     depends_on:
       - mysql
     image: wordpress:latest
     ports:
       - "8000:80"
     restart: always
     environment:
       WORDPRESS_DB_HOST: mysql:3306
       WORDPRESS_DB_USER: wordpress
       WORDPRESS_DB_PASSWORD: wordpress
     volumes:
        - ./docker/wp-content/uploads:/var/www/html/wp-content/uploads
        - ./docker/wp-content/themes:/var/www/html/wp-content/themes
        - ./docker/wp-content/plugins:/var/www/html/wp-content/plugins
volumes:
    db_data:
```