### PR TITLE
Add a warning for cases where WORDPRESS_CONFIG_EXTRA will not take effect

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -152,6 +152,13 @@ if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROT
 
 EOPHP
 			chown "$user:$group" wp-config.php
+		elif [ -e wp-config.php ] && [ -n "$WORDPRESS_CONFIG_EXTRA" ] && [[ "$(< wp-config.php)" != *"$WORDPRESS_CONFIG_EXTRA"* ]]; then
+			# (if the config file already contains the requested PHP code, don't print a warning)
+			echo >&2
+			echo >&2 'WARNING: environment variable "WORDPRESS_CONFIG_EXTRA" is set, but "wp-config.php" already exists'
+			echo >&2 '  The contents of this variable will _not_ be inserted into the existing "wp-config.php" file.'
+			echo >&2 '  (see https://github.com/docker-library/wordpress/issues/333 for more details)'
+			echo >&2
 		fi
 
 		# see http://stackoverflow.com/a/2705678/433558

--- a/php5.6/apache/docker-entrypoint.sh
+++ b/php5.6/apache/docker-entrypoint.sh
@@ -152,6 +152,13 @@ if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROT
 
 EOPHP
 			chown "$user:$group" wp-config.php
+		elif [ -e wp-config.php ] && [ -n "$WORDPRESS_CONFIG_EXTRA" ] && [[ "$(< wp-config.php)" != *"$WORDPRESS_CONFIG_EXTRA"* ]]; then
+			# (if the config file already contains the requested PHP code, don't print a warning)
+			echo >&2
+			echo >&2 'WARNING: environment variable "WORDPRESS_CONFIG_EXTRA" is set, but "wp-config.php" already exists'
+			echo >&2 '  The contents of this variable will _not_ be inserted into the existing "wp-config.php" file.'
+			echo >&2 '  (see https://github.com/docker-library/wordpress/issues/333 for more details)'
+			echo >&2
 		fi
 
 		# see http://stackoverflow.com/a/2705678/433558

--- a/php5.6/fpm-alpine/docker-entrypoint.sh
+++ b/php5.6/fpm-alpine/docker-entrypoint.sh
@@ -152,6 +152,13 @@ if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROT
 
 EOPHP
 			chown "$user:$group" wp-config.php
+		elif [ -e wp-config.php ] && [ -n "$WORDPRESS_CONFIG_EXTRA" ] && [[ "$(< wp-config.php)" != *"$WORDPRESS_CONFIG_EXTRA"* ]]; then
+			# (if the config file already contains the requested PHP code, don't print a warning)
+			echo >&2
+			echo >&2 'WARNING: environment variable "WORDPRESS_CONFIG_EXTRA" is set, but "wp-config.php" already exists'
+			echo >&2 '  The contents of this variable will _not_ be inserted into the existing "wp-config.php" file.'
+			echo >&2 '  (see https://github.com/docker-library/wordpress/issues/333 for more details)'
+			echo >&2
 		fi
 
 		# see http://stackoverflow.com/a/2705678/433558

--- a/php5.6/fpm/docker-entrypoint.sh
+++ b/php5.6/fpm/docker-entrypoint.sh
@@ -152,6 +152,13 @@ if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROT
 
 EOPHP
 			chown "$user:$group" wp-config.php
+		elif [ -e wp-config.php ] && [ -n "$WORDPRESS_CONFIG_EXTRA" ] && [[ "$(< wp-config.php)" != *"$WORDPRESS_CONFIG_EXTRA"* ]]; then
+			# (if the config file already contains the requested PHP code, don't print a warning)
+			echo >&2
+			echo >&2 'WARNING: environment variable "WORDPRESS_CONFIG_EXTRA" is set, but "wp-config.php" already exists'
+			echo >&2 '  The contents of this variable will _not_ be inserted into the existing "wp-config.php" file.'
+			echo >&2 '  (see https://github.com/docker-library/wordpress/issues/333 for more details)'
+			echo >&2
 		fi
 
 		# see http://stackoverflow.com/a/2705678/433558

--- a/php7.0/apache/docker-entrypoint.sh
+++ b/php7.0/apache/docker-entrypoint.sh
@@ -152,6 +152,13 @@ if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROT
 
 EOPHP
 			chown "$user:$group" wp-config.php
+		elif [ -e wp-config.php ] && [ -n "$WORDPRESS_CONFIG_EXTRA" ] && [[ "$(< wp-config.php)" != *"$WORDPRESS_CONFIG_EXTRA"* ]]; then
+			# (if the config file already contains the requested PHP code, don't print a warning)
+			echo >&2
+			echo >&2 'WARNING: environment variable "WORDPRESS_CONFIG_EXTRA" is set, but "wp-config.php" already exists'
+			echo >&2 '  The contents of this variable will _not_ be inserted into the existing "wp-config.php" file.'
+			echo >&2 '  (see https://github.com/docker-library/wordpress/issues/333 for more details)'
+			echo >&2
 		fi
 
 		# see http://stackoverflow.com/a/2705678/433558

--- a/php7.0/fpm-alpine/docker-entrypoint.sh
+++ b/php7.0/fpm-alpine/docker-entrypoint.sh
@@ -152,6 +152,13 @@ if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROT
 
 EOPHP
 			chown "$user:$group" wp-config.php
+		elif [ -e wp-config.php ] && [ -n "$WORDPRESS_CONFIG_EXTRA" ] && [[ "$(< wp-config.php)" != *"$WORDPRESS_CONFIG_EXTRA"* ]]; then
+			# (if the config file already contains the requested PHP code, don't print a warning)
+			echo >&2
+			echo >&2 'WARNING: environment variable "WORDPRESS_CONFIG_EXTRA" is set, but "wp-config.php" already exists'
+			echo >&2 '  The contents of this variable will _not_ be inserted into the existing "wp-config.php" file.'
+			echo >&2 '  (see https://github.com/docker-library/wordpress/issues/333 for more details)'
+			echo >&2
 		fi
 
 		# see http://stackoverflow.com/a/2705678/433558

--- a/php7.0/fpm/docker-entrypoint.sh
+++ b/php7.0/fpm/docker-entrypoint.sh
@@ -152,6 +152,13 @@ if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROT
 
 EOPHP
 			chown "$user:$group" wp-config.php
+		elif [ -e wp-config.php ] && [ -n "$WORDPRESS_CONFIG_EXTRA" ] && [[ "$(< wp-config.php)" != *"$WORDPRESS_CONFIG_EXTRA"* ]]; then
+			# (if the config file already contains the requested PHP code, don't print a warning)
+			echo >&2
+			echo >&2 'WARNING: environment variable "WORDPRESS_CONFIG_EXTRA" is set, but "wp-config.php" already exists'
+			echo >&2 '  The contents of this variable will _not_ be inserted into the existing "wp-config.php" file.'
+			echo >&2 '  (see https://github.com/docker-library/wordpress/issues/333 for more details)'
+			echo >&2
 		fi
 
 		# see http://stackoverflow.com/a/2705678/433558

--- a/php7.1/apache/docker-entrypoint.sh
+++ b/php7.1/apache/docker-entrypoint.sh
@@ -152,6 +152,13 @@ if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROT
 
 EOPHP
 			chown "$user:$group" wp-config.php
+		elif [ -e wp-config.php ] && [ -n "$WORDPRESS_CONFIG_EXTRA" ] && [[ "$(< wp-config.php)" != *"$WORDPRESS_CONFIG_EXTRA"* ]]; then
+			# (if the config file already contains the requested PHP code, don't print a warning)
+			echo >&2
+			echo >&2 'WARNING: environment variable "WORDPRESS_CONFIG_EXTRA" is set, but "wp-config.php" already exists'
+			echo >&2 '  The contents of this variable will _not_ be inserted into the existing "wp-config.php" file.'
+			echo >&2 '  (see https://github.com/docker-library/wordpress/issues/333 for more details)'
+			echo >&2
 		fi
 
 		# see http://stackoverflow.com/a/2705678/433558

--- a/php7.1/fpm-alpine/docker-entrypoint.sh
+++ b/php7.1/fpm-alpine/docker-entrypoint.sh
@@ -152,6 +152,13 @@ if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROT
 
 EOPHP
 			chown "$user:$group" wp-config.php
+		elif [ -e wp-config.php ] && [ -n "$WORDPRESS_CONFIG_EXTRA" ] && [[ "$(< wp-config.php)" != *"$WORDPRESS_CONFIG_EXTRA"* ]]; then
+			# (if the config file already contains the requested PHP code, don't print a warning)
+			echo >&2
+			echo >&2 'WARNING: environment variable "WORDPRESS_CONFIG_EXTRA" is set, but "wp-config.php" already exists'
+			echo >&2 '  The contents of this variable will _not_ be inserted into the existing "wp-config.php" file.'
+			echo >&2 '  (see https://github.com/docker-library/wordpress/issues/333 for more details)'
+			echo >&2
 		fi
 
 		# see http://stackoverflow.com/a/2705678/433558

--- a/php7.1/fpm/docker-entrypoint.sh
+++ b/php7.1/fpm/docker-entrypoint.sh
@@ -152,6 +152,13 @@ if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROT
 
 EOPHP
 			chown "$user:$group" wp-config.php
+		elif [ -e wp-config.php ] && [ -n "$WORDPRESS_CONFIG_EXTRA" ] && [[ "$(< wp-config.php)" != *"$WORDPRESS_CONFIG_EXTRA"* ]]; then
+			# (if the config file already contains the requested PHP code, don't print a warning)
+			echo >&2
+			echo >&2 'WARNING: environment variable "WORDPRESS_CONFIG_EXTRA" is set, but "wp-config.php" already exists'
+			echo >&2 '  The contents of this variable will _not_ be inserted into the existing "wp-config.php" file.'
+			echo >&2 '  (see https://github.com/docker-library/wordpress/issues/333 for more details)'
+			echo >&2
 		fi
 
 		# see http://stackoverflow.com/a/2705678/433558

--- a/php7.2/apache/docker-entrypoint.sh
+++ b/php7.2/apache/docker-entrypoint.sh
@@ -152,6 +152,13 @@ if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROT
 
 EOPHP
 			chown "$user:$group" wp-config.php
+		elif [ -e wp-config.php ] && [ -n "$WORDPRESS_CONFIG_EXTRA" ] && [[ "$(< wp-config.php)" != *"$WORDPRESS_CONFIG_EXTRA"* ]]; then
+			# (if the config file already contains the requested PHP code, don't print a warning)
+			echo >&2
+			echo >&2 'WARNING: environment variable "WORDPRESS_CONFIG_EXTRA" is set, but "wp-config.php" already exists'
+			echo >&2 '  The contents of this variable will _not_ be inserted into the existing "wp-config.php" file.'
+			echo >&2 '  (see https://github.com/docker-library/wordpress/issues/333 for more details)'
+			echo >&2
 		fi
 
 		# see http://stackoverflow.com/a/2705678/433558

--- a/php7.2/fpm-alpine/docker-entrypoint.sh
+++ b/php7.2/fpm-alpine/docker-entrypoint.sh
@@ -152,6 +152,13 @@ if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROT
 
 EOPHP
 			chown "$user:$group" wp-config.php
+		elif [ -e wp-config.php ] && [ -n "$WORDPRESS_CONFIG_EXTRA" ] && [[ "$(< wp-config.php)" != *"$WORDPRESS_CONFIG_EXTRA"* ]]; then
+			# (if the config file already contains the requested PHP code, don't print a warning)
+			echo >&2
+			echo >&2 'WARNING: environment variable "WORDPRESS_CONFIG_EXTRA" is set, but "wp-config.php" already exists'
+			echo >&2 '  The contents of this variable will _not_ be inserted into the existing "wp-config.php" file.'
+			echo >&2 '  (see https://github.com/docker-library/wordpress/issues/333 for more details)'
+			echo >&2
 		fi
 
 		# see http://stackoverflow.com/a/2705678/433558

--- a/php7.2/fpm/docker-entrypoint.sh
+++ b/php7.2/fpm/docker-entrypoint.sh
@@ -152,6 +152,13 @@ if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROT
 
 EOPHP
 			chown "$user:$group" wp-config.php
+		elif [ -e wp-config.php ] && [ -n "$WORDPRESS_CONFIG_EXTRA" ] && [[ "$(< wp-config.php)" != *"$WORDPRESS_CONFIG_EXTRA"* ]]; then
+			# (if the config file already contains the requested PHP code, don't print a warning)
+			echo >&2
+			echo >&2 'WARNING: environment variable "WORDPRESS_CONFIG_EXTRA" is set, but "wp-config.php" already exists'
+			echo >&2 '  The contents of this variable will _not_ be inserted into the existing "wp-config.php" file.'
+			echo >&2 '  (see https://github.com/docker-library/wordpress/issues/333 for more details)'
+			echo >&2
 		fi
 
 		# see http://stackoverflow.com/a/2705678/433558


### PR DESCRIPTION
Closes #333

If `WORDPRESS_CONFIG_EXTRA` is set, `wp-config.php` already exists, _and_ the contents of `WORDPRESS_CONFIG_EXTRA` do not already exist in the existing `wp-config.php`, this will print a warning (which then points to #333, which includes discussion of workarounds for folks who need this value to be updated more dynamically).