### PR TITLE
Remove "--one-file-system"

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -48,7 +48,6 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		fi
 		tar --create \
 			--file - \
-			--one-file-system \
 			--directory /usr/src/wordpress \
 			--owner "$user" --group "$group" \
 			. | tar --extract --file -

--- a/php5.6/apache/docker-entrypoint.sh
+++ b/php5.6/apache/docker-entrypoint.sh
@@ -48,7 +48,6 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		fi
 		tar --create \
 			--file - \
-			--one-file-system \
 			--directory /usr/src/wordpress \
 			--owner "$user" --group "$group" \
 			. | tar --extract --file -

--- a/php5.6/fpm-alpine/docker-entrypoint.sh
+++ b/php5.6/fpm-alpine/docker-entrypoint.sh
@@ -48,7 +48,6 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		fi
 		tar --create \
 			--file - \
-			--one-file-system \
 			--directory /usr/src/wordpress \
 			--owner "$user" --group "$group" \
 			. | tar --extract --file -

--- a/php5.6/fpm/docker-entrypoint.sh
+++ b/php5.6/fpm/docker-entrypoint.sh
@@ -48,7 +48,6 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		fi
 		tar --create \
 			--file - \
-			--one-file-system \
 			--directory /usr/src/wordpress \
 			--owner "$user" --group "$group" \
 			. | tar --extract --file -

--- a/php7.0/apache/docker-entrypoint.sh
+++ b/php7.0/apache/docker-entrypoint.sh
@@ -48,7 +48,6 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		fi
 		tar --create \
 			--file - \
-			--one-file-system \
 			--directory /usr/src/wordpress \
 			--owner "$user" --group "$group" \
 			. | tar --extract --file -

--- a/php7.0/fpm-alpine/docker-entrypoint.sh
+++ b/php7.0/fpm-alpine/docker-entrypoint.sh
@@ -48,7 +48,6 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		fi
 		tar --create \
 			--file - \
-			--one-file-system \
 			--directory /usr/src/wordpress \
 			--owner "$user" --group "$group" \
 			. | tar --extract --file -

--- a/php7.0/fpm/docker-entrypoint.sh
+++ b/php7.0/fpm/docker-entrypoint.sh
@@ -48,7 +48,6 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		fi
 		tar --create \
 			--file - \
-			--one-file-system \
 			--directory /usr/src/wordpress \
 			--owner "$user" --group "$group" \
 			. | tar --extract --file -

--- a/php7.1/apache/docker-entrypoint.sh
+++ b/php7.1/apache/docker-entrypoint.sh
@@ -48,7 +48,6 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		fi
 		tar --create \
 			--file - \
-			--one-file-system \
 			--directory /usr/src/wordpress \
 			--owner "$user" --group "$group" \
 			. | tar --extract --file -

--- a/php7.1/fpm-alpine/docker-entrypoint.sh
+++ b/php7.1/fpm-alpine/docker-entrypoint.sh
@@ -48,7 +48,6 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		fi
 		tar --create \
 			--file - \
-			--one-file-system \
 			--directory /usr/src/wordpress \
 			--owner "$user" --group "$group" \
 			. | tar --extract --file -

--- a/php7.1/fpm/docker-entrypoint.sh
+++ b/php7.1/fpm/docker-entrypoint.sh
@@ -48,7 +48,6 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		fi
 		tar --create \
 			--file - \
-			--one-file-system \
 			--directory /usr/src/wordpress \
 			--owner "$user" --group "$group" \
 			. | tar --extract --file -

--- a/php7.2/apache/docker-entrypoint.sh
+++ b/php7.2/apache/docker-entrypoint.sh
@@ -48,7 +48,6 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		fi
 		tar --create \
 			--file - \
-			--one-file-system \
 			--directory /usr/src/wordpress \
 			--owner "$user" --group "$group" \
 			. | tar --extract --file -

--- a/php7.2/fpm-alpine/docker-entrypoint.sh
+++ b/php7.2/fpm-alpine/docker-entrypoint.sh
@@ -48,7 +48,6 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		fi
 		tar --create \
 			--file - \
-			--one-file-system \
 			--directory /usr/src/wordpress \
 			--owner "$user" --group "$group" \
 			. | tar --extract --file -

--- a/php7.2/fpm/docker-entrypoint.sh
+++ b/php7.2/fpm/docker-entrypoint.sh
@@ -48,7 +48,6 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		fi
 		tar --create \
 			--file - \
-			--one-file-system \
 			--directory /usr/src/wordpress \
 			--owner "$user" --group "$group" \
 			. | tar --extract --file -


### PR DESCRIPTION
This allows users to mount things into `/usr/src/wordpress` that will then be copied into `/var/www/html` during runtime.

Closes #344