### PR TITLE
Add "--no-overwrite-dir" to "tar" invocation for running as an arbitrary user

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,6 +29,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 			apache2*)
 				user="${APACHE_RUN_USER:-www-data}"
 				group="${APACHE_RUN_GROUP:-www-data}"
+
+				# strip off any '#' symbol ('#1000' is valid syntax for Apache)
+				pound='#'
+				user="${user#$pound}"
+				group="${group#$pound}"
 				;;
 			*) # php-fpm
 				user='www-data'

--- a/php5.6/apache/docker-entrypoint.sh
+++ b/php5.6/apache/docker-entrypoint.sh
@@ -29,6 +29,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 			apache2*)
 				user="${APACHE_RUN_USER:-www-data}"
 				group="${APACHE_RUN_GROUP:-www-data}"
+
+				# strip off any '#' symbol ('#1000' is valid syntax for Apache)
+				pound='#'
+				user="${user#$pound}"
+				group="${group#$pound}"
 				;;
 			*) # php-fpm
 				user='www-data'

--- a/php5.6/fpm-alpine/docker-entrypoint.sh
+++ b/php5.6/fpm-alpine/docker-entrypoint.sh
@@ -29,6 +29,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 			apache2*)
 				user="${APACHE_RUN_USER:-www-data}"
 				group="${APACHE_RUN_GROUP:-www-data}"
+
+				# strip off any '#' symbol ('#1000' is valid syntax for Apache)
+				pound='#'
+				user="${user#$pound}"
+				group="${group#$pound}"
 				;;
 			*) # php-fpm
 				user='www-data'

--- a/php5.6/fpm/docker-entrypoint.sh
+++ b/php5.6/fpm/docker-entrypoint.sh
@@ -29,6 +29,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 			apache2*)
 				user="${APACHE_RUN_USER:-www-data}"
 				group="${APACHE_RUN_GROUP:-www-data}"
+
+				# strip off any '#' symbol ('#1000' is valid syntax for Apache)
+				pound='#'
+				user="${user#$pound}"
+				group="${group#$pound}"
 				;;
 			*) # php-fpm
 				user='www-data'

--- a/php7.0/apache/docker-entrypoint.sh
+++ b/php7.0/apache/docker-entrypoint.sh
@@ -29,6 +29,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 			apache2*)
 				user="${APACHE_RUN_USER:-www-data}"
 				group="${APACHE_RUN_GROUP:-www-data}"
+
+				# strip off any '#' symbol ('#1000' is valid syntax for Apache)
+				pound='#'
+				user="${user#$pound}"
+				group="${group#$pound}"
 				;;
 			*) # php-fpm
 				user='www-data'

--- a/php7.0/fpm-alpine/docker-entrypoint.sh
+++ b/php7.0/fpm-alpine/docker-entrypoint.sh
@@ -29,6 +29,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 			apache2*)
 				user="${APACHE_RUN_USER:-www-data}"
 				group="${APACHE_RUN_GROUP:-www-data}"
+
+				# strip off any '#' symbol ('#1000' is valid syntax for Apache)
+				pound='#'
+				user="${user#$pound}"
+				group="${group#$pound}"
 				;;
 			*) # php-fpm
 				user='www-data'

--- a/php7.0/fpm/docker-entrypoint.sh
+++ b/php7.0/fpm/docker-entrypoint.sh
@@ -29,6 +29,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 			apache2*)
 				user="${APACHE_RUN_USER:-www-data}"
 				group="${APACHE_RUN_GROUP:-www-data}"
+
+				# strip off any '#' symbol ('#1000' is valid syntax for Apache)
+				pound='#'
+				user="${user#$pound}"
+				group="${group#$pound}"
 				;;
 			*) # php-fpm
 				user='www-data'

--- a/php7.1/apache/docker-entrypoint.sh
+++ b/php7.1/apache/docker-entrypoint.sh
@@ -29,6 +29,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 			apache2*)
 				user="${APACHE_RUN_USER:-www-data}"
 				group="${APACHE_RUN_GROUP:-www-data}"
+
+				# strip off any '#' symbol ('#1000' is valid syntax for Apache)
+				pound='#'
+				user="${user#$pound}"
+				group="${group#$pound}"
 				;;
 			*) # php-fpm
 				user='www-data'

--- a/php7.1/fpm-alpine/docker-entrypoint.sh
+++ b/php7.1/fpm-alpine/docker-entrypoint.sh
@@ -29,6 +29,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 			apache2*)
 				user="${APACHE_RUN_USER:-www-data}"
 				group="${APACHE_RUN_GROUP:-www-data}"
+
+				# strip off any '#' symbol ('#1000' is valid syntax for Apache)
+				pound='#'
+				user="${user#$pound}"
+				group="${group#$pound}"
 				;;
 			*) # php-fpm
 				user='www-data'

--- a/php7.1/fpm/docker-entrypoint.sh
+++ b/php7.1/fpm/docker-entrypoint.sh
@@ -29,6 +29,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 			apache2*)
 				user="${APACHE_RUN_USER:-www-data}"
 				group="${APACHE_RUN_GROUP:-www-data}"
+
+				# strip off any '#' symbol ('#1000' is valid syntax for Apache)
+				pound='#'
+				user="${user#$pound}"
+				group="${group#$pound}"
 				;;
 			*) # php-fpm
 				user='www-data'

--- a/php7.2/apache/docker-entrypoint.sh
+++ b/php7.2/apache/docker-entrypoint.sh
@@ -29,6 +29,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 			apache2*)
 				user="${APACHE_RUN_USER:-www-data}"
 				group="${APACHE_RUN_GROUP:-www-data}"
+
+				# strip off any '#' symbol ('#1000' is valid syntax for Apache)
+				pound='#'
+				user="${user#$pound}"
+				group="${group#$pound}"
 				;;
 			*) # php-fpm
 				user='www-data'

--- a/php7.2/fpm-alpine/docker-entrypoint.sh
+++ b/php7.2/fpm-alpine/docker-entrypoint.sh
@@ -29,6 +29,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 			apache2*)
 				user="${APACHE_RUN_USER:-www-data}"
 				group="${APACHE_RUN_GROUP:-www-data}"
+
+				# strip off any '#' symbol ('#1000' is valid syntax for Apache)
+				pound='#'
+				user="${user#$pound}"
+				group="${group#$pound}"
 				;;
 			*) # php-fpm
 				user='www-data'

--- a/php7.2/fpm/docker-entrypoint.sh
+++ b/php7.2/fpm/docker-entrypoint.sh
@@ -29,6 +29,11 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 			apache2*)
 				user="${APACHE_RUN_USER:-www-data}"
 				group="${APACHE_RUN_GROUP:-www-data}"
+
+				# strip off any '#' symbol ('#1000' is valid syntax for Apache)
+				pound='#'
+				user="${user#$pound}"
+				group="${group#$pound}"
 				;;
 			*) # php-fpm
 				user='www-data'


### PR DESCRIPTION
This fixes `tar: .: Cannot utime: Operation not permitted` and `tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted` (which we get currently).

This combined with https://github.com/docker-library/php/pull/755 fixes part of what @wglambert noted in https://github.com/docker-library/php/issues/754#issuecomment-441825192.