### PR TITLE
Replace PHP 7.0 by PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ env:
   - VARIANT=php7.2/fpm
   - VARIANT=php7.2/fpm-alpine
   - VARIANT=php7.2/cli
+  - VARIANT=php7.3/apache
+  - VARIANT=php7.3/fpm
+  - VARIANT=php7.3/fpm-alpine
+  - VARIANT=php7.3/cli
 
 install:
   - git clone https://github.com/docker-library/official-images.git ~/official-images

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -13,6 +13,7 @@ RUN set -ex; \
 	apk add --no-cache --virtual .build-deps \
 		libjpeg-turbo-dev \
 		libpng-dev \
+		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \

--- a/Dockerfile-cli.template
+++ b/Dockerfile-cli.template
@@ -6,6 +6,7 @@ RUN set -ex; \
 	apk add --no-cache --virtual .build-deps \
 		libjpeg-turbo-dev \
 		libpng-dev \
+		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -9,6 +9,7 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		libjpeg-dev \
 		libpng-dev \
+		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \

--- a/php7.3/apache/Dockerfile
+++ b/php7.3/apache/Dockerfile
@@ -9,6 +9,7 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		libjpeg-dev \
 		libpng-dev \
+		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \

--- a/php7.3/apache/Dockerfile
+++ b/php7.3/apache/Dockerfile
@@ -1,0 +1,60 @@
+FROM php:7.3-apache
+
+# install the PHP extensions we need
+RUN set -ex; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libjpeg-dev \
+		libpng-dev \
+	; \
+	\
+	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	docker-php-ext-install gd mysqli opcache zip; \
+	\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+		echo 'opcache.fast_shutdown=1'; \
+		echo 'opcache.enable_cli=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+RUN a2enmod rewrite expires
+
+VOLUME /var/www/html
+
+ENV WORDPRESS_VERSION 5.0.2
+ENV WORDPRESS_SHA1 4a6971d35eb92e2fc30034141b1c865e8c156add
+
+RUN set -ex; \
+	curl -o wordpress.tar.gz -fSL "https://wordpress.org/wordpress-${WORDPRESS_VERSION}.tar.gz"; \
+	echo "$WORDPRESS_SHA1 *wordpress.tar.gz" | sha1sum -c -; \
+# upstream tarballs include ./wordpress/ so this gives us /usr/src/wordpress
+	tar -xzf wordpress.tar.gz -C /usr/src/; \
+	rm wordpress.tar.gz; \
+	chown -R www-data:www-data /usr/src/wordpress
+
+COPY docker-entrypoint.sh /usr/local/bin/
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/php7.3/apache/docker-entrypoint.sh
+++ b/php7.3/apache/docker-entrypoint.sh
@@ -1,0 +1,281 @@
+#!/bin/bash
+set -euo pipefail
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+	if [ "$(id -u)" = '0' ]; then
+		case "$1" in
+			apache2*)
+				user="${APACHE_RUN_USER:-www-data}"
+				group="${APACHE_RUN_GROUP:-www-data}"
+
+				# strip off any '#' symbol ('#1000' is valid syntax for Apache)
+				pound='#'
+				user="${user#$pound}"
+				group="${group#$pound}"
+				;;
+			*) # php-fpm
+				user='www-data'
+				group='www-data'
+				;;
+		esac
+	else
+		user="$(id -u)"
+		group="$(id -g)"
+	fi
+
+	if [ ! -e index.php ] && [ ! -e wp-includes/version.php ]; then
+		echo >&2 "WordPress not found in $PWD - copying now..."
+		if [ -n "$(ls -A)" ]; then
+			echo >&2 "WARNING: $PWD is not empty! (copying anyhow)"
+		fi
+		sourceTarArgs=(
+			--create
+			--file -
+			--directory /usr/src/wordpress
+			--owner "$user" --group "$group"
+		)
+		targetTarArgs=(
+			--extract
+			--file -
+		)
+		if [ "$user" != '0' ]; then
+			# avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
+			targetTarArgs+=( --no-overwrite-dir )
+		fi
+		tar "${sourceTarArgs[@]}" . | tar "${targetTarArgs[@]}"
+		echo >&2 "Complete! WordPress has been successfully copied to $PWD"
+		if [ ! -e .htaccess ]; then
+			# NOTE: The "Indexes" option is disabled in the php:apache base image
+			cat > .htaccess <<-'EOF'
+				# BEGIN WordPress
+				<IfModule mod_rewrite.c>
+				RewriteEngine On
+				RewriteBase /
+				RewriteRule ^index\.php$ - [L]
+				RewriteCond %{REQUEST_FILENAME} !-f
+				RewriteCond %{REQUEST_FILENAME} !-d
+				RewriteRule . /index.php [L]
+				</IfModule>
+				# END WordPress
+			EOF
+			chown "$user:$group" .htaccess
+		fi
+	fi
+
+	# TODO handle WordPress upgrades magically in the same way, but only if wp-includes/version.php's $wp_version is less than /usr/src/wordpress/wp-includes/version.php's $wp_version
+
+	# allow any of these "Authentication Unique Keys and Salts." to be specified via
+	# environment variables with a "WORDPRESS_" prefix (ie, "WORDPRESS_AUTH_KEY")
+	uniqueEnvs=(
+		AUTH_KEY
+		SECURE_AUTH_KEY
+		LOGGED_IN_KEY
+		NONCE_KEY
+		AUTH_SALT
+		SECURE_AUTH_SALT
+		LOGGED_IN_SALT
+		NONCE_SALT
+	)
+	envs=(
+		WORDPRESS_DB_HOST
+		WORDPRESS_DB_USER
+		WORDPRESS_DB_PASSWORD
+		WORDPRESS_DB_NAME
+		WORDPRESS_DB_CHARSET
+		WORDPRESS_DB_COLLATE
+		"${uniqueEnvs[@]/#/WORDPRESS_}"
+		WORDPRESS_TABLE_PREFIX
+		WORDPRESS_DEBUG
+		WORDPRESS_CONFIG_EXTRA
+	)
+	haveConfig=
+	for e in "${envs[@]}"; do
+		file_env "$e"
+		if [ -z "$haveConfig" ] && [ -n "${!e}" ]; then
+			haveConfig=1
+		fi
+	done
+
+	# linking backwards-compatibility
+	if [ -n "${!MYSQL_ENV_MYSQL_*}" ]; then
+		haveConfig=1
+		# host defaults to "mysql" below if unspecified
+		: "${WORDPRESS_DB_USER:=${MYSQL_ENV_MYSQL_USER:-root}}"
+		if [ "$WORDPRESS_DB_USER" = 'root' ]; then
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}}"
+		else
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_PASSWORD:-}}"
+		fi
+		: "${WORDPRESS_DB_NAME:=${MYSQL_ENV_MYSQL_DATABASE:-}}"
+	fi
+
+	# only touch "wp-config.php" if we have environment-supplied configuration values
+	if [ "$haveConfig" ]; then
+		: "${WORDPRESS_DB_HOST:=mysql}"
+		: "${WORDPRESS_DB_USER:=root}"
+		: "${WORDPRESS_DB_PASSWORD:=}"
+		: "${WORDPRESS_DB_NAME:=wordpress}"
+		: "${WORDPRESS_DB_CHARSET:=utf8}"
+		: "${WORDPRESS_DB_COLLATE:=}"
+
+		# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
+		# https://github.com/docker-library/wordpress/issues/116
+		# https://github.com/WordPress/WordPress/commit/1acedc542fba2482bab88ec70d4bea4b997a92e4
+		sed -ri -e 's/\r$//' wp-config*
+
+		if [ ! -e wp-config.php ]; then
+			awk '
+				/^\/\*.*stop editing.*\*\/$/ && c == 0 {
+					c = 1
+					system("cat")
+					if (ENVIRON["WORDPRESS_CONFIG_EXTRA"]) {
+						print "// WORDPRESS_CONFIG_EXTRA"
+						print ENVIRON["WORDPRESS_CONFIG_EXTRA"] "\n"
+					}
+				}
+				{ print }
+			' wp-config-sample.php > wp-config.php <<'EOPHP'
+// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
+// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+	$_SERVER['HTTPS'] = 'on';
+}
+
+EOPHP
+			chown "$user:$group" wp-config.php
+		elif [ -e wp-config.php ] && [ -n "$WORDPRESS_CONFIG_EXTRA" ] && [[ "$(< wp-config.php)" != *"$WORDPRESS_CONFIG_EXTRA"* ]]; then
+			# (if the config file already contains the requested PHP code, don't print a warning)
+			echo >&2
+			echo >&2 'WARNING: environment variable "WORDPRESS_CONFIG_EXTRA" is set, but "wp-config.php" already exists'
+			echo >&2 '  The contents of this variable will _not_ be inserted into the existing "wp-config.php" file.'
+			echo >&2 '  (see https://github.com/docker-library/wordpress/issues/333 for more details)'
+			echo >&2
+		fi
+
+		# see http://stackoverflow.com/a/2705678/433558
+		sed_escape_lhs() {
+			echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
+		}
+		sed_escape_rhs() {
+			echo "$@" | sed -e 's/[\/&]/\\&/g'
+		}
+		php_escape() {
+			local escaped="$(php -r 'var_export(('"$2"') $argv[1]);' -- "$1")"
+			if [ "$2" = 'string' ] && [ "${escaped:0:1}" = "'" ]; then
+				escaped="${escaped//$'\n'/"' + \"\\n\" + '"}"
+			fi
+			echo "$escaped"
+		}
+		set_config() {
+			key="$1"
+			value="$2"
+			var_type="${3:-string}"
+			start="(['\"])$(sed_escape_lhs "$key")\2\s*,"
+			end="\);"
+			if [ "${key:0:1}" = '$' ]; then
+				start="^(\s*)$(sed_escape_lhs "$key")\s*="
+				end=";"
+			fi
+			sed -ri -e "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
+		}
+
+		set_config 'DB_HOST' "$WORDPRESS_DB_HOST"
+		set_config 'DB_USER' "$WORDPRESS_DB_USER"
+		set_config 'DB_PASSWORD' "$WORDPRESS_DB_PASSWORD"
+		set_config 'DB_NAME' "$WORDPRESS_DB_NAME"
+		set_config 'DB_CHARSET' "$WORDPRESS_DB_CHARSET"
+		set_config 'DB_COLLATE' "$WORDPRESS_DB_COLLATE"
+
+		for unique in "${uniqueEnvs[@]}"; do
+			uniqVar="WORDPRESS_$unique"
+			if [ -n "${!uniqVar}" ]; then
+				set_config "$unique" "${!uniqVar}"
+			else
+				# if not specified, let's generate a random value
+				currentVal="$(sed -rn -e "s/define\((([\'\"])$unique\2\s*,\s*)(['\"])(.*)\3\);/\4/p" wp-config.php)"
+				if [ "$currentVal" = 'put your unique phrase here' ]; then
+					set_config "$unique" "$(head -c1m /dev/urandom | sha1sum | cut -d' ' -f1)"
+				fi
+			fi
+		done
+
+		if [ "$WORDPRESS_TABLE_PREFIX" ]; then
+			set_config '$table_prefix' "$WORDPRESS_TABLE_PREFIX"
+		fi
+
+		if [ "$WORDPRESS_DEBUG" ]; then
+			set_config 'WP_DEBUG' 1 boolean
+		fi
+
+		TERM=dumb php -- <<'EOPHP'
+<?php
+// database might not exist, so let's try creating it (just to be safe)
+
+$stderr = fopen('php://stderr', 'w');
+
+// https://codex.wordpress.org/Editing_wp-config.php#MySQL_Alternate_Port
+//   "hostname:port"
+// https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
+//   "hostname:unix-socket-path"
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
+$port = 0;
+if (is_numeric($socket)) {
+	$port = (int) $socket;
+	$socket = null;
+}
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
+
+$maxTries = 10;
+do {
+	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);
+	if ($mysql->connect_error) {
+		fwrite($stderr, "\n" . 'MySQL Connection Error: (' . $mysql->connect_errno . ') ' . $mysql->connect_error . "\n");
+		--$maxTries;
+		if ($maxTries <= 0) {
+			exit(1);
+		}
+		sleep(3);
+	}
+} while ($mysql->connect_error);
+
+if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_string($dbName) . '`')) {
+	fwrite($stderr, "\n" . 'MySQL "CREATE DATABASE" Error: ' . $mysql->error . "\n");
+	$mysql->close();
+	exit(1);
+}
+
+$mysql->close();
+EOPHP
+	fi
+
+	# now that we're definitely done writing configuration, let's clear out the relevant envrionment variables (so that stray "phpinfo()" calls don't leak secrets from our code)
+	for e in "${envs[@]}"; do
+		unset "$e"
+	done
+fi
+
+exec "$@"

--- a/php7.3/cli/Dockerfile
+++ b/php7.3/cli/Dockerfile
@@ -1,0 +1,82 @@
+FROM php:7.3-alpine
+
+# install the PHP extensions we need
+RUN set -ex; \
+	\
+	apk add --no-cache --virtual .build-deps \
+		libjpeg-turbo-dev \
+		libpng-dev \
+	; \
+	\
+	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	docker-php-ext-install gd mysqli opcache zip; \
+	\
+	runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)"; \
+	apk add --virtual .wordpress-phpexts-rundeps $runDeps; \
+	apk del .build-deps
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+		echo 'opcache.fast_shutdown=1'; \
+		echo 'opcache.enable_cli=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+# install wp-cli dependencies
+RUN apk add --no-cache \
+# bash is needed for 'wp shell': https://github.com/wp-cli/shell-command/blob/b8dafcc2a2eba5732fdee70be077675a302848e9/src/WP_CLI/REPL.php#L104
+		bash \
+		less \
+		mysql-client
+
+RUN set -ex; \
+	mkdir -p /var/www/html; \
+	chown -R www-data:www-data /var/www/html
+WORKDIR /var/www/html
+VOLUME /var/www/html
+
+# https://make.wordpress.org/cli/2018/05/31/gpg-signature-change/
+# pub   rsa2048 2018-05-31 [SC]
+#       63AF 7AA1 5067 C056 16FD  DD88 A3A2 E8F2 26F0 BC06
+# uid           [ unknown] WP-CLI Releases <releases@wp-cli.org>
+# sub   rsa2048 2018-05-31 [E]
+ENV WORDPRESS_CLI_GPG_KEY 63AF7AA15067C05616FDDD88A3A2E8F226F0BC06
+
+ENV WORDPRESS_CLI_VERSION 2.1.0
+ENV WORDPRESS_CLI_SHA512 c2ff556c21c85bbcf11be38d058224f53d3d57a1da45320ecf0079d480063dcdc11b5029b94b0b181c1e3bec84745300cd848d28065c0d3619f598980cc17244
+
+RUN set -ex; \
+	\
+	apk add --no-cache --virtual .fetch-deps \
+		gnupg \
+	; \
+	\
+	curl -o /usr/local/bin/wp.gpg -fSL "https://github.com/wp-cli/wp-cli/releases/download/v${WORDPRESS_CLI_VERSION}/wp-cli-${WORDPRESS_CLI_VERSION}.phar.gpg"; \
+	\
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$WORDPRESS_CLI_GPG_KEY"; \
+	gpg --batch --decrypt --output /usr/local/bin/wp /usr/local/bin/wp.gpg; \
+	command -v gpgconf && gpgconf --kill all || :; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/wp.gpg; \
+	\
+	echo "$WORDPRESS_CLI_SHA512 */usr/local/bin/wp" | sha512sum -c -; \
+	chmod +x /usr/local/bin/wp; \
+	\
+	apk del .fetch-deps; \
+	\
+	wp --allow-root --version
+
+COPY docker-entrypoint.sh /usr/local/bin/
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+USER www-data
+CMD ["wp", "shell"]

--- a/php7.3/cli/Dockerfile
+++ b/php7.3/cli/Dockerfile
@@ -6,6 +6,7 @@ RUN set -ex; \
 	apk add --no-cache --virtual .build-deps \
 		libjpeg-turbo-dev \
 		libpng-dev \
+		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \

--- a/php7.3/cli/docker-entrypoint.sh
+++ b/php7.3/cli/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -euo pipefail
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- wp "$@"
+fi
+
+# if our command is a valid wp-cli subcommand, let's invoke it through wp-cli instead
+# (this allows for "docker run wordpress:cli help", etc)
+if wp --path=/dev/null help "$1" > /dev/null 2>&1; then
+	set -- wp "$@"
+fi
+
+exec "$@"

--- a/php7.3/fpm-alpine/Dockerfile
+++ b/php7.3/fpm-alpine/Dockerfile
@@ -13,6 +13,7 @@ RUN set -ex; \
 	apk add --no-cache --virtual .build-deps \
 		libjpeg-turbo-dev \
 		libpng-dev \
+		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \

--- a/php7.3/fpm-alpine/Dockerfile
+++ b/php7.3/fpm-alpine/Dockerfile
@@ -1,0 +1,57 @@
+FROM php:7.3-fpm-alpine
+
+# docker-entrypoint.sh dependencies
+RUN apk add --no-cache \
+# in theory, docker-entrypoint.sh is POSIX-compliant, but priority is a working, consistent image
+		bash \
+# BusyBox sed is not sufficient for some of our sed expressions
+		sed
+
+# install the PHP extensions we need
+RUN set -ex; \
+	\
+	apk add --no-cache --virtual .build-deps \
+		libjpeg-turbo-dev \
+		libpng-dev \
+	; \
+	\
+	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	docker-php-ext-install gd mysqli opcache zip; \
+	\
+	runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)"; \
+	apk add --virtual .wordpress-phpexts-rundeps $runDeps; \
+	apk del .build-deps
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+		echo 'opcache.fast_shutdown=1'; \
+		echo 'opcache.enable_cli=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+VOLUME /var/www/html
+
+ENV WORDPRESS_VERSION 5.0.2
+ENV WORDPRESS_SHA1 4a6971d35eb92e2fc30034141b1c865e8c156add
+
+RUN set -ex; \
+	curl -o wordpress.tar.gz -fSL "https://wordpress.org/wordpress-${WORDPRESS_VERSION}.tar.gz"; \
+	echo "$WORDPRESS_SHA1 *wordpress.tar.gz" | sha1sum -c -; \
+# upstream tarballs include ./wordpress/ so this gives us /usr/src/wordpress
+	tar -xzf wordpress.tar.gz -C /usr/src/; \
+	rm wordpress.tar.gz; \
+	chown -R www-data:www-data /usr/src/wordpress
+
+COPY docker-entrypoint.sh /usr/local/bin/
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["php-fpm"]

--- a/php7.3/fpm-alpine/docker-entrypoint.sh
+++ b/php7.3/fpm-alpine/docker-entrypoint.sh
@@ -1,0 +1,281 @@
+#!/bin/bash
+set -euo pipefail
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+	if [ "$(id -u)" = '0' ]; then
+		case "$1" in
+			apache2*)
+				user="${APACHE_RUN_USER:-www-data}"
+				group="${APACHE_RUN_GROUP:-www-data}"
+
+				# strip off any '#' symbol ('#1000' is valid syntax for Apache)
+				pound='#'
+				user="${user#$pound}"
+				group="${group#$pound}"
+				;;
+			*) # php-fpm
+				user='www-data'
+				group='www-data'
+				;;
+		esac
+	else
+		user="$(id -u)"
+		group="$(id -g)"
+	fi
+
+	if [ ! -e index.php ] && [ ! -e wp-includes/version.php ]; then
+		echo >&2 "WordPress not found in $PWD - copying now..."
+		if [ -n "$(ls -A)" ]; then
+			echo >&2 "WARNING: $PWD is not empty! (copying anyhow)"
+		fi
+		sourceTarArgs=(
+			--create
+			--file -
+			--directory /usr/src/wordpress
+			--owner "$user" --group "$group"
+		)
+		targetTarArgs=(
+			--extract
+			--file -
+		)
+		if [ "$user" != '0' ]; then
+			# avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
+			targetTarArgs+=( --no-overwrite-dir )
+		fi
+		tar "${sourceTarArgs[@]}" . | tar "${targetTarArgs[@]}"
+		echo >&2 "Complete! WordPress has been successfully copied to $PWD"
+		if [ ! -e .htaccess ]; then
+			# NOTE: The "Indexes" option is disabled in the php:apache base image
+			cat > .htaccess <<-'EOF'
+				# BEGIN WordPress
+				<IfModule mod_rewrite.c>
+				RewriteEngine On
+				RewriteBase /
+				RewriteRule ^index\.php$ - [L]
+				RewriteCond %{REQUEST_FILENAME} !-f
+				RewriteCond %{REQUEST_FILENAME} !-d
+				RewriteRule . /index.php [L]
+				</IfModule>
+				# END WordPress
+			EOF
+			chown "$user:$group" .htaccess
+		fi
+	fi
+
+	# TODO handle WordPress upgrades magically in the same way, but only if wp-includes/version.php's $wp_version is less than /usr/src/wordpress/wp-includes/version.php's $wp_version
+
+	# allow any of these "Authentication Unique Keys and Salts." to be specified via
+	# environment variables with a "WORDPRESS_" prefix (ie, "WORDPRESS_AUTH_KEY")
+	uniqueEnvs=(
+		AUTH_KEY
+		SECURE_AUTH_KEY
+		LOGGED_IN_KEY
+		NONCE_KEY
+		AUTH_SALT
+		SECURE_AUTH_SALT
+		LOGGED_IN_SALT
+		NONCE_SALT
+	)
+	envs=(
+		WORDPRESS_DB_HOST
+		WORDPRESS_DB_USER
+		WORDPRESS_DB_PASSWORD
+		WORDPRESS_DB_NAME
+		WORDPRESS_DB_CHARSET
+		WORDPRESS_DB_COLLATE
+		"${uniqueEnvs[@]/#/WORDPRESS_}"
+		WORDPRESS_TABLE_PREFIX
+		WORDPRESS_DEBUG
+		WORDPRESS_CONFIG_EXTRA
+	)
+	haveConfig=
+	for e in "${envs[@]}"; do
+		file_env "$e"
+		if [ -z "$haveConfig" ] && [ -n "${!e}" ]; then
+			haveConfig=1
+		fi
+	done
+
+	# linking backwards-compatibility
+	if [ -n "${!MYSQL_ENV_MYSQL_*}" ]; then
+		haveConfig=1
+		# host defaults to "mysql" below if unspecified
+		: "${WORDPRESS_DB_USER:=${MYSQL_ENV_MYSQL_USER:-root}}"
+		if [ "$WORDPRESS_DB_USER" = 'root' ]; then
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}}"
+		else
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_PASSWORD:-}}"
+		fi
+		: "${WORDPRESS_DB_NAME:=${MYSQL_ENV_MYSQL_DATABASE:-}}"
+	fi
+
+	# only touch "wp-config.php" if we have environment-supplied configuration values
+	if [ "$haveConfig" ]; then
+		: "${WORDPRESS_DB_HOST:=mysql}"
+		: "${WORDPRESS_DB_USER:=root}"
+		: "${WORDPRESS_DB_PASSWORD:=}"
+		: "${WORDPRESS_DB_NAME:=wordpress}"
+		: "${WORDPRESS_DB_CHARSET:=utf8}"
+		: "${WORDPRESS_DB_COLLATE:=}"
+
+		# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
+		# https://github.com/docker-library/wordpress/issues/116
+		# https://github.com/WordPress/WordPress/commit/1acedc542fba2482bab88ec70d4bea4b997a92e4
+		sed -ri -e 's/\r$//' wp-config*
+
+		if [ ! -e wp-config.php ]; then
+			awk '
+				/^\/\*.*stop editing.*\*\/$/ && c == 0 {
+					c = 1
+					system("cat")
+					if (ENVIRON["WORDPRESS_CONFIG_EXTRA"]) {
+						print "// WORDPRESS_CONFIG_EXTRA"
+						print ENVIRON["WORDPRESS_CONFIG_EXTRA"] "\n"
+					}
+				}
+				{ print }
+			' wp-config-sample.php > wp-config.php <<'EOPHP'
+// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
+// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+	$_SERVER['HTTPS'] = 'on';
+}
+
+EOPHP
+			chown "$user:$group" wp-config.php
+		elif [ -e wp-config.php ] && [ -n "$WORDPRESS_CONFIG_EXTRA" ] && [[ "$(< wp-config.php)" != *"$WORDPRESS_CONFIG_EXTRA"* ]]; then
+			# (if the config file already contains the requested PHP code, don't print a warning)
+			echo >&2
+			echo >&2 'WARNING: environment variable "WORDPRESS_CONFIG_EXTRA" is set, but "wp-config.php" already exists'
+			echo >&2 '  The contents of this variable will _not_ be inserted into the existing "wp-config.php" file.'
+			echo >&2 '  (see https://github.com/docker-library/wordpress/issues/333 for more details)'
+			echo >&2
+		fi
+
+		# see http://stackoverflow.com/a/2705678/433558
+		sed_escape_lhs() {
+			echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
+		}
+		sed_escape_rhs() {
+			echo "$@" | sed -e 's/[\/&]/\\&/g'
+		}
+		php_escape() {
+			local escaped="$(php -r 'var_export(('"$2"') $argv[1]);' -- "$1")"
+			if [ "$2" = 'string' ] && [ "${escaped:0:1}" = "'" ]; then
+				escaped="${escaped//$'\n'/"' + \"\\n\" + '"}"
+			fi
+			echo "$escaped"
+		}
+		set_config() {
+			key="$1"
+			value="$2"
+			var_type="${3:-string}"
+			start="(['\"])$(sed_escape_lhs "$key")\2\s*,"
+			end="\);"
+			if [ "${key:0:1}" = '$' ]; then
+				start="^(\s*)$(sed_escape_lhs "$key")\s*="
+				end=";"
+			fi
+			sed -ri -e "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
+		}
+
+		set_config 'DB_HOST' "$WORDPRESS_DB_HOST"
+		set_config 'DB_USER' "$WORDPRESS_DB_USER"
+		set_config 'DB_PASSWORD' "$WORDPRESS_DB_PASSWORD"
+		set_config 'DB_NAME' "$WORDPRESS_DB_NAME"
+		set_config 'DB_CHARSET' "$WORDPRESS_DB_CHARSET"
+		set_config 'DB_COLLATE' "$WORDPRESS_DB_COLLATE"
+
+		for unique in "${uniqueEnvs[@]}"; do
+			uniqVar="WORDPRESS_$unique"
+			if [ -n "${!uniqVar}" ]; then
+				set_config "$unique" "${!uniqVar}"
+			else
+				# if not specified, let's generate a random value
+				currentVal="$(sed -rn -e "s/define\((([\'\"])$unique\2\s*,\s*)(['\"])(.*)\3\);/\4/p" wp-config.php)"
+				if [ "$currentVal" = 'put your unique phrase here' ]; then
+					set_config "$unique" "$(head -c1m /dev/urandom | sha1sum | cut -d' ' -f1)"
+				fi
+			fi
+		done
+
+		if [ "$WORDPRESS_TABLE_PREFIX" ]; then
+			set_config '$table_prefix' "$WORDPRESS_TABLE_PREFIX"
+		fi
+
+		if [ "$WORDPRESS_DEBUG" ]; then
+			set_config 'WP_DEBUG' 1 boolean
+		fi
+
+		TERM=dumb php -- <<'EOPHP'
+<?php
+// database might not exist, so let's try creating it (just to be safe)
+
+$stderr = fopen('php://stderr', 'w');
+
+// https://codex.wordpress.org/Editing_wp-config.php#MySQL_Alternate_Port
+//   "hostname:port"
+// https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
+//   "hostname:unix-socket-path"
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
+$port = 0;
+if (is_numeric($socket)) {
+	$port = (int) $socket;
+	$socket = null;
+}
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
+
+$maxTries = 10;
+do {
+	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);
+	if ($mysql->connect_error) {
+		fwrite($stderr, "\n" . 'MySQL Connection Error: (' . $mysql->connect_errno . ') ' . $mysql->connect_error . "\n");
+		--$maxTries;
+		if ($maxTries <= 0) {
+			exit(1);
+		}
+		sleep(3);
+	}
+} while ($mysql->connect_error);
+
+if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_string($dbName) . '`')) {
+	fwrite($stderr, "\n" . 'MySQL "CREATE DATABASE" Error: ' . $mysql->error . "\n");
+	$mysql->close();
+	exit(1);
+}
+
+$mysql->close();
+EOPHP
+	fi
+
+	# now that we're definitely done writing configuration, let's clear out the relevant envrionment variables (so that stray "phpinfo()" calls don't leak secrets from our code)
+	for e in "${envs[@]}"; do
+		unset "$e"
+	done
+fi
+
+exec "$@"

--- a/php7.3/fpm/Dockerfile
+++ b/php7.3/fpm/Dockerfile
@@ -1,0 +1,58 @@
+FROM php:7.3-fpm
+
+# install the PHP extensions we need
+RUN set -ex; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	\
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libjpeg-dev \
+		libpng-dev \
+	; \
+	\
+	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	docker-php-ext-install gd mysqli opcache zip; \
+	\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	apt-mark manual $savedAptMark; \
+	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+		| awk '/=>/ { print $3 }' \
+		| sort -u \
+		| xargs -r dpkg-query -S \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -rt apt-mark manual; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+		echo 'opcache.fast_shutdown=1'; \
+		echo 'opcache.enable_cli=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+VOLUME /var/www/html
+
+ENV WORDPRESS_VERSION 5.0.2
+ENV WORDPRESS_SHA1 4a6971d35eb92e2fc30034141b1c865e8c156add
+
+RUN set -ex; \
+	curl -o wordpress.tar.gz -fSL "https://wordpress.org/wordpress-${WORDPRESS_VERSION}.tar.gz"; \
+	echo "$WORDPRESS_SHA1 *wordpress.tar.gz" | sha1sum -c -; \
+# upstream tarballs include ./wordpress/ so this gives us /usr/src/wordpress
+	tar -xzf wordpress.tar.gz -C /usr/src/; \
+	rm wordpress.tar.gz; \
+	chown -R www-data:www-data /usr/src/wordpress
+
+COPY docker-entrypoint.sh /usr/local/bin/
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["php-fpm"]

--- a/php7.3/fpm/Dockerfile
+++ b/php7.3/fpm/Dockerfile
@@ -9,6 +9,7 @@ RUN set -ex; \
 	apt-get install -y --no-install-recommends \
 		libjpeg-dev \
 		libpng-dev \
+		libzip-dev \
 	; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \

--- a/php7.3/fpm/docker-entrypoint.sh
+++ b/php7.3/fpm/docker-entrypoint.sh
@@ -1,0 +1,281 @@
+#!/bin/bash
+set -euo pipefail
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+	if [ "$(id -u)" = '0' ]; then
+		case "$1" in
+			apache2*)
+				user="${APACHE_RUN_USER:-www-data}"
+				group="${APACHE_RUN_GROUP:-www-data}"
+
+				# strip off any '#' symbol ('#1000' is valid syntax for Apache)
+				pound='#'
+				user="${user#$pound}"
+				group="${group#$pound}"
+				;;
+			*) # php-fpm
+				user='www-data'
+				group='www-data'
+				;;
+		esac
+	else
+		user="$(id -u)"
+		group="$(id -g)"
+	fi
+
+	if [ ! -e index.php ] && [ ! -e wp-includes/version.php ]; then
+		echo >&2 "WordPress not found in $PWD - copying now..."
+		if [ -n "$(ls -A)" ]; then
+			echo >&2 "WARNING: $PWD is not empty! (copying anyhow)"
+		fi
+		sourceTarArgs=(
+			--create
+			--file -
+			--directory /usr/src/wordpress
+			--owner "$user" --group "$group"
+		)
+		targetTarArgs=(
+			--extract
+			--file -
+		)
+		if [ "$user" != '0' ]; then
+			# avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
+			targetTarArgs+=( --no-overwrite-dir )
+		fi
+		tar "${sourceTarArgs[@]}" . | tar "${targetTarArgs[@]}"
+		echo >&2 "Complete! WordPress has been successfully copied to $PWD"
+		if [ ! -e .htaccess ]; then
+			# NOTE: The "Indexes" option is disabled in the php:apache base image
+			cat > .htaccess <<-'EOF'
+				# BEGIN WordPress
+				<IfModule mod_rewrite.c>
+				RewriteEngine On
+				RewriteBase /
+				RewriteRule ^index\.php$ - [L]
+				RewriteCond %{REQUEST_FILENAME} !-f
+				RewriteCond %{REQUEST_FILENAME} !-d
+				RewriteRule . /index.php [L]
+				</IfModule>
+				# END WordPress
+			EOF
+			chown "$user:$group" .htaccess
+		fi
+	fi
+
+	# TODO handle WordPress upgrades magically in the same way, but only if wp-includes/version.php's $wp_version is less than /usr/src/wordpress/wp-includes/version.php's $wp_version
+
+	# allow any of these "Authentication Unique Keys and Salts." to be specified via
+	# environment variables with a "WORDPRESS_" prefix (ie, "WORDPRESS_AUTH_KEY")
+	uniqueEnvs=(
+		AUTH_KEY
+		SECURE_AUTH_KEY
+		LOGGED_IN_KEY
+		NONCE_KEY
+		AUTH_SALT
+		SECURE_AUTH_SALT
+		LOGGED_IN_SALT
+		NONCE_SALT
+	)
+	envs=(
+		WORDPRESS_DB_HOST
+		WORDPRESS_DB_USER
+		WORDPRESS_DB_PASSWORD
+		WORDPRESS_DB_NAME
+		WORDPRESS_DB_CHARSET
+		WORDPRESS_DB_COLLATE
+		"${uniqueEnvs[@]/#/WORDPRESS_}"
+		WORDPRESS_TABLE_PREFIX
+		WORDPRESS_DEBUG
+		WORDPRESS_CONFIG_EXTRA
+	)
+	haveConfig=
+	for e in "${envs[@]}"; do
+		file_env "$e"
+		if [ -z "$haveConfig" ] && [ -n "${!e}" ]; then
+			haveConfig=1
+		fi
+	done
+
+	# linking backwards-compatibility
+	if [ -n "${!MYSQL_ENV_MYSQL_*}" ]; then
+		haveConfig=1
+		# host defaults to "mysql" below if unspecified
+		: "${WORDPRESS_DB_USER:=${MYSQL_ENV_MYSQL_USER:-root}}"
+		if [ "$WORDPRESS_DB_USER" = 'root' ]; then
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_ROOT_PASSWORD:-}}"
+		else
+			: "${WORDPRESS_DB_PASSWORD:=${MYSQL_ENV_MYSQL_PASSWORD:-}}"
+		fi
+		: "${WORDPRESS_DB_NAME:=${MYSQL_ENV_MYSQL_DATABASE:-}}"
+	fi
+
+	# only touch "wp-config.php" if we have environment-supplied configuration values
+	if [ "$haveConfig" ]; then
+		: "${WORDPRESS_DB_HOST:=mysql}"
+		: "${WORDPRESS_DB_USER:=root}"
+		: "${WORDPRESS_DB_PASSWORD:=}"
+		: "${WORDPRESS_DB_NAME:=wordpress}"
+		: "${WORDPRESS_DB_CHARSET:=utf8}"
+		: "${WORDPRESS_DB_COLLATE:=}"
+
+		# version 4.4.1 decided to switch to windows line endings, that breaks our seds and awks
+		# https://github.com/docker-library/wordpress/issues/116
+		# https://github.com/WordPress/WordPress/commit/1acedc542fba2482bab88ec70d4bea4b997a92e4
+		sed -ri -e 's/\r$//' wp-config*
+
+		if [ ! -e wp-config.php ]; then
+			awk '
+				/^\/\*.*stop editing.*\*\/$/ && c == 0 {
+					c = 1
+					system("cat")
+					if (ENVIRON["WORDPRESS_CONFIG_EXTRA"]) {
+						print "// WORDPRESS_CONFIG_EXTRA"
+						print ENVIRON["WORDPRESS_CONFIG_EXTRA"] "\n"
+					}
+				}
+				{ print }
+			' wp-config-sample.php > wp-config.php <<'EOPHP'
+// If we're behind a proxy server and using HTTPS, we need to alert Wordpress of that fact
+// see also http://codex.wordpress.org/Administration_Over_SSL#Using_a_Reverse_Proxy
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+	$_SERVER['HTTPS'] = 'on';
+}
+
+EOPHP
+			chown "$user:$group" wp-config.php
+		elif [ -e wp-config.php ] && [ -n "$WORDPRESS_CONFIG_EXTRA" ] && [[ "$(< wp-config.php)" != *"$WORDPRESS_CONFIG_EXTRA"* ]]; then
+			# (if the config file already contains the requested PHP code, don't print a warning)
+			echo >&2
+			echo >&2 'WARNING: environment variable "WORDPRESS_CONFIG_EXTRA" is set, but "wp-config.php" already exists'
+			echo >&2 '  The contents of this variable will _not_ be inserted into the existing "wp-config.php" file.'
+			echo >&2 '  (see https://github.com/docker-library/wordpress/issues/333 for more details)'
+			echo >&2
+		fi
+
+		# see http://stackoverflow.com/a/2705678/433558
+		sed_escape_lhs() {
+			echo "$@" | sed -e 's/[]\/$*.^|[]/\\&/g'
+		}
+		sed_escape_rhs() {
+			echo "$@" | sed -e 's/[\/&]/\\&/g'
+		}
+		php_escape() {
+			local escaped="$(php -r 'var_export(('"$2"') $argv[1]);' -- "$1")"
+			if [ "$2" = 'string' ] && [ "${escaped:0:1}" = "'" ]; then
+				escaped="${escaped//$'\n'/"' + \"\\n\" + '"}"
+			fi
+			echo "$escaped"
+		}
+		set_config() {
+			key="$1"
+			value="$2"
+			var_type="${3:-string}"
+			start="(['\"])$(sed_escape_lhs "$key")\2\s*,"
+			end="\);"
+			if [ "${key:0:1}" = '$' ]; then
+				start="^(\s*)$(sed_escape_lhs "$key")\s*="
+				end=";"
+			fi
+			sed -ri -e "s/($start\s*).*($end)$/\1$(sed_escape_rhs "$(php_escape "$value" "$var_type")")\3/" wp-config.php
+		}
+
+		set_config 'DB_HOST' "$WORDPRESS_DB_HOST"
+		set_config 'DB_USER' "$WORDPRESS_DB_USER"
+		set_config 'DB_PASSWORD' "$WORDPRESS_DB_PASSWORD"
+		set_config 'DB_NAME' "$WORDPRESS_DB_NAME"
+		set_config 'DB_CHARSET' "$WORDPRESS_DB_CHARSET"
+		set_config 'DB_COLLATE' "$WORDPRESS_DB_COLLATE"
+
+		for unique in "${uniqueEnvs[@]}"; do
+			uniqVar="WORDPRESS_$unique"
+			if [ -n "${!uniqVar}" ]; then
+				set_config "$unique" "${!uniqVar}"
+			else
+				# if not specified, let's generate a random value
+				currentVal="$(sed -rn -e "s/define\((([\'\"])$unique\2\s*,\s*)(['\"])(.*)\3\);/\4/p" wp-config.php)"
+				if [ "$currentVal" = 'put your unique phrase here' ]; then
+					set_config "$unique" "$(head -c1m /dev/urandom | sha1sum | cut -d' ' -f1)"
+				fi
+			fi
+		done
+
+		if [ "$WORDPRESS_TABLE_PREFIX" ]; then
+			set_config '$table_prefix' "$WORDPRESS_TABLE_PREFIX"
+		fi
+
+		if [ "$WORDPRESS_DEBUG" ]; then
+			set_config 'WP_DEBUG' 1 boolean
+		fi
+
+		TERM=dumb php -- <<'EOPHP'
+<?php
+// database might not exist, so let's try creating it (just to be safe)
+
+$stderr = fopen('php://stderr', 'w');
+
+// https://codex.wordpress.org/Editing_wp-config.php#MySQL_Alternate_Port
+//   "hostname:port"
+// https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
+//   "hostname:unix-socket-path"
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
+$port = 0;
+if (is_numeric($socket)) {
+	$port = (int) $socket;
+	$socket = null;
+}
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
+
+$maxTries = 10;
+do {
+	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);
+	if ($mysql->connect_error) {
+		fwrite($stderr, "\n" . 'MySQL Connection Error: (' . $mysql->connect_errno . ') ' . $mysql->connect_error . "\n");
+		--$maxTries;
+		if ($maxTries <= 0) {
+			exit(1);
+		}
+		sleep(3);
+	}
+} while ($mysql->connect_error);
+
+if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_string($dbName) . '`')) {
+	fwrite($stderr, "\n" . 'MySQL "CREATE DATABASE" Error: ' . $mysql->error . "\n");
+	$mysql->close();
+	exit(1);
+}
+
+$mysql->close();
+EOPHP
+	fi
+
+	# now that we're definitely done writing configuration, let's clear out the relevant envrionment variables (so that stray "phpinfo()" calls don't leak secrets from our code)
+	for e in "${envs[@]}"; do
+		unset "$e"
+	done
+fi
+
+exec "$@"

--- a/update.sh
+++ b/update.sh
@@ -70,6 +70,12 @@ for phpVersion in "${phpVersions[@]}"; do
 				-e 's!%%CMD%%!'"$cmd"'!g' \
 				"Dockerfile-${base}.template" > "$dir/Dockerfile"
 
+			if [[ "$phpVersion" != 7.3 ]]; then
+				sed -ri \
+					-e '/libzip-dev/d' \
+					"$dir/Dockerfile"
+			fi
+
 			cp -a "$entrypoint" "$dir/docker-entrypoint.sh"
 		)
 

--- a/update.sh
+++ b/update.sh
@@ -19,6 +19,8 @@ cliVersion="$(
 )"
 cliSha512="$(curl -fsSL "https://github.com/wp-cli/wp-cli/releases/download/v${cliVersion}/wp-cli-${cliVersion}.phar.sha512")"
 
+echo "$current (CLI $cliVersion)"
+
 declare -A variantExtras=(
 	[apache]='\nRUN a2enmod rewrite expires\n'
 	[fpm]=''
@@ -56,28 +58,26 @@ for phpVersion in "${phpVersions[@]}"; do
 			entrypoint='cli-entrypoint.sh'
 		fi
 
-		(
-			set -x
+		sed -r \
+			-e 's!%%WORDPRESS_VERSION%%!'"$current"'!g' \
+			-e 's!%%WORDPRESS_SHA1%%!'"$sha1"'!g' \
+			-e 's!%%PHP_VERSION%%!'"$phpVersion"'!g' \
+			-e 's!%%VARIANT%%!'"$variant"'!g' \
+			-e 's!%%WORDPRESS_CLI_VERSION%%!'"$cliVersion"'!g' \
+			-e 's!%%WORDPRESS_CLI_SHA512%%!'"$cliSha512"'!g' \
+			-e 's!%%VARIANT_EXTRAS%%!'"$extras"'!g' \
+			-e 's!%%CMD%%!'"$cmd"'!g' \
+			"Dockerfile-${base}.template" > "$dir/Dockerfile"
 
-			sed -r \
-				-e 's!%%WORDPRESS_VERSION%%!'"$current"'!g' \
-				-e 's!%%WORDPRESS_SHA1%%!'"$sha1"'!g' \
-				-e 's!%%PHP_VERSION%%!'"$phpVersion"'!g' \
-				-e 's!%%VARIANT%%!'"$variant"'!g' \
-				-e 's!%%WORDPRESS_CLI_VERSION%%!'"$cliVersion"'!g' \
-				-e 's!%%WORDPRESS_CLI_SHA512%%!'"$cliSha512"'!g' \
-				-e 's!%%VARIANT_EXTRAS%%!'"$extras"'!g' \
-				-e 's!%%CMD%%!'"$cmd"'!g' \
-				"Dockerfile-${base}.template" > "$dir/Dockerfile"
-
-			if [[ "$phpVersion" != 7.3 ]]; then
+		case "$phpVersion" in
+			7.1 | 7.2 )
 				sed -ri \
 					-e '/libzip-dev/d' \
 					"$dir/Dockerfile"
-			fi
+				;;
+		esac
 
-			cp -a "$entrypoint" "$dir/docker-entrypoint.sh"
-		)
+		cp -a "$entrypoint" "$dir/docker-entrypoint.sh"
 
 		travisEnv+='\n  - VARIANT='"$dir"
 	done


### PR DESCRIPTION
Since Wordpress has some [remaining bugs](https://core.trac.wordpress.org/query?status=!closed&keywords=~php73) with 7.3 the default remains 7.2 for now.