### PR TITLE
remove --path argument so plugins are loaded

### DIFF
--- a/cli-entrypoint.sh
+++ b/cli-entrypoint.sh
@@ -2,13 +2,9 @@
 set -euo pipefail
 
 # first arg is `-f` or `--some-option`
-if [ "${1#-}" != "$1" ]; then
-	set -- wp "$@"
-fi
-
-# if our command is a valid wp-cli subcommand, let's invoke it through wp-cli instead
+# or if our command is a valid wp-cli subcommand, let's invoke it through wp-cli instead
 # (this allows for "docker run wordpress:cli help", etc)
-if wp --path=/dev/null help "$1" > /dev/null 2>&1; then
+if [ "${1#-}" != "$1" ] || wp help "$1" > /dev/null 2>&1; then
 	set -- wp "$@"
 fi
 

--- a/php7.2/cli/docker-entrypoint.sh
+++ b/php7.2/cli/docker-entrypoint.sh
@@ -2,13 +2,9 @@
 set -euo pipefail
 
 # first arg is `-f` or `--some-option`
-if [ "${1#-}" != "$1" ]; then
-	set -- wp "$@"
-fi
-
-# if our command is a valid wp-cli subcommand, let's invoke it through wp-cli instead
+# or if our command is a valid wp-cli subcommand, let's invoke it through wp-cli instead
 # (this allows for "docker run wordpress:cli help", etc)
-if wp --path=/dev/null help "$1" > /dev/null 2>&1; then
+if [ "${1#-}" != "$1" ] || wp help "$1" > /dev/null 2>&1; then
 	set -- wp "$@"
 fi
 

--- a/php7.3/cli/docker-entrypoint.sh
+++ b/php7.3/cli/docker-entrypoint.sh
@@ -2,13 +2,9 @@
 set -euo pipefail
 
 # first arg is `-f` or `--some-option`
-if [ "${1#-}" != "$1" ]; then
-	set -- wp "$@"
-fi
-
-# if our command is a valid wp-cli subcommand, let's invoke it through wp-cli instead
+# or if our command is a valid wp-cli subcommand, let's invoke it through wp-cli instead
 # (this allows for "docker run wordpress:cli help", etc)
-if wp --path=/dev/null help "$1" > /dev/null 2>&1; then
+if [ "${1#-}" != "$1" ] || wp help "$1" > /dev/null 2>&1; then
 	set -- wp "$@"
 fi
 

--- a/php7.4/cli/docker-entrypoint.sh
+++ b/php7.4/cli/docker-entrypoint.sh
@@ -2,13 +2,9 @@
 set -euo pipefail
 
 # first arg is `-f` or `--some-option`
-if [ "${1#-}" != "$1" ]; then
-	set -- wp "$@"
-fi
-
-# if our command is a valid wp-cli subcommand, let's invoke it through wp-cli instead
+# or if our command is a valid wp-cli subcommand, let's invoke it through wp-cli instead
 # (this allows for "docker run wordpress:cli help", etc)
-if wp --path=/dev/null help "$1" > /dev/null 2>&1; then
+if [ "${1#-}" != "$1" ] || wp help "$1" > /dev/null 2>&1; then
 	set -- wp "$@"
 fi
 


### PR DESCRIPTION
Remove `--path=/dev/null` so if the current directory is a wordpress directory it will load the plugins and correctly prefix "wp" when needed. The second if is changed to elif because the conditions are exclusive and if the first test matched the second doesn't need to run.