### PR TITLE
enable mod_remoteip and add config for X-Forwarded-For IP address

### DIFF
--- a/apache-extras.template
+++ b/apache-extras.template
@@ -1,0 +1,18 @@
+RUN set -eux; \
+	a2enmod rewrite expires; \
+	\
+# https://httpd.apache.org/docs/2.4/mod/mod_remoteip.html
+	a2enmod remoteip; \
+	{ \
+		echo 'RemoteIPHeader X-Forwarded-For'; \
+# these IP ranges are reserved for "private" use and should thus *usually* be safe inside Docker
+		echo 'RemoteIPTrustedProxy 10.0.0.0/8'; \
+		echo 'RemoteIPTrustedProxy 172.16.0.0/12'; \
+		echo 'RemoteIPTrustedProxy 192.168.0.0/16'; \
+		echo 'RemoteIPTrustedProxy 169.254.0.0/16'; \
+		echo 'RemoteIPTrustedProxy 127.0.0.0/8'; \
+	} > /etc/apache2/conf-available/remoteip.conf; \
+	a2enconf remoteip; \
+# https://github.com/docker-library/wordpress/issues/383#issuecomment-507886512
+# (replace all instances of "%h" with "%a" in LogFormat)
+	find /etc/apache2 -name '*.conf' -exec sed -ri 's/([[:space:]]*LogFormat[[:space:]]+"[^"]*)%h([^"]*")/\1%a\2/g' '{}' +

--- a/php7.1/apache/Dockerfile
+++ b/php7.1/apache/Dockerfile
@@ -62,7 +62,15 @@ RUN { \
 		echo 'html_errors = Off'; \
 	} > /usr/local/etc/php/conf.d/error-logging.ini
 
-RUN a2enmod rewrite expires
+RUN a2enmod rewrite expires remoteip
+
+RUN { \
+        echo 'RemoteIPHeader X-Forwarded-For' ; \
+        echo 'RemoteIPTrustedProxy 10.0.0.0/8' ; \
+        echo 'RemoteIPTrustedProxy 172.16.0.0/12' ; \
+        echo 'RemoteIPTrustedProxy 192.168.0.0/16' ; \
+    } > /etc/apache2/conf-available/remoteip.conf ; \
+    a2enconf remoteip
 
 VOLUME /var/www/html
 

--- a/php7.1/apache/Dockerfile
+++ b/php7.1/apache/Dockerfile
@@ -62,15 +62,24 @@ RUN { \
 		echo 'html_errors = Off'; \
 	} > /usr/local/etc/php/conf.d/error-logging.ini
 
-RUN a2enmod rewrite expires remoteip
-
-RUN { \
-        echo 'RemoteIPHeader X-Forwarded-For' ; \
-        echo 'RemoteIPTrustedProxy 10.0.0.0/8' ; \
-        echo 'RemoteIPTrustedProxy 172.16.0.0/12' ; \
-        echo 'RemoteIPTrustedProxy 192.168.0.0/16' ; \
-    } > /etc/apache2/conf-available/remoteip.conf ; \
-    a2enconf remoteip
+RUN set -eux; \
+	a2enmod rewrite expires; \
+	\
+# https://httpd.apache.org/docs/2.4/mod/mod_remoteip.html
+	a2enmod remoteip; \
+	{ \
+		echo 'RemoteIPHeader X-Forwarded-For'; \
+# these IP ranges are reserved for "private" use and should thus *usually* be safe inside Docker
+		echo 'RemoteIPTrustedProxy 10.0.0.0/8'; \
+		echo 'RemoteIPTrustedProxy 172.16.0.0/12'; \
+		echo 'RemoteIPTrustedProxy 192.168.0.0/16'; \
+		echo 'RemoteIPTrustedProxy 169.254.0.0/16'; \
+		echo 'RemoteIPTrustedProxy 127.0.0.0/8'; \
+	} > /etc/apache2/conf-available/remoteip.conf; \
+	a2enconf remoteip; \
+# https://github.com/docker-library/wordpress/issues/383#issuecomment-507886512
+# (replace all instances of "%h" with "%a" in LogFormat)
+	find /etc/apache2 -name '*.conf' -exec sed -ri 's/([[:space:]]*LogFormat[[:space:]]+"[^"]*)%h([^"]*")/\1%a\2/g' '{}' +
 
 VOLUME /var/www/html
 

--- a/php7.2/apache/Dockerfile
+++ b/php7.2/apache/Dockerfile
@@ -62,7 +62,15 @@ RUN { \
 		echo 'html_errors = Off'; \
 	} > /usr/local/etc/php/conf.d/error-logging.ini
 
-RUN a2enmod rewrite expires
+RUN a2enmod rewrite expires remoteip
+
+RUN { \
+        echo 'RemoteIPHeader X-Forwarded-For' ; \
+        echo 'RemoteIPTrustedProxy 10.0.0.0/8' ; \
+        echo 'RemoteIPTrustedProxy 172.16.0.0/12' ; \
+        echo 'RemoteIPTrustedProxy 192.168.0.0/16' ; \
+    } > /etc/apache2/conf-available/remoteip.conf ; \
+    a2enconf remoteip
 
 VOLUME /var/www/html
 

--- a/php7.2/apache/Dockerfile
+++ b/php7.2/apache/Dockerfile
@@ -62,15 +62,24 @@ RUN { \
 		echo 'html_errors = Off'; \
 	} > /usr/local/etc/php/conf.d/error-logging.ini
 
-RUN a2enmod rewrite expires remoteip
-
-RUN { \
-        echo 'RemoteIPHeader X-Forwarded-For' ; \
-        echo 'RemoteIPTrustedProxy 10.0.0.0/8' ; \
-        echo 'RemoteIPTrustedProxy 172.16.0.0/12' ; \
-        echo 'RemoteIPTrustedProxy 192.168.0.0/16' ; \
-    } > /etc/apache2/conf-available/remoteip.conf ; \
-    a2enconf remoteip
+RUN set -eux; \
+	a2enmod rewrite expires; \
+	\
+# https://httpd.apache.org/docs/2.4/mod/mod_remoteip.html
+	a2enmod remoteip; \
+	{ \
+		echo 'RemoteIPHeader X-Forwarded-For'; \
+# these IP ranges are reserved for "private" use and should thus *usually* be safe inside Docker
+		echo 'RemoteIPTrustedProxy 10.0.0.0/8'; \
+		echo 'RemoteIPTrustedProxy 172.16.0.0/12'; \
+		echo 'RemoteIPTrustedProxy 192.168.0.0/16'; \
+		echo 'RemoteIPTrustedProxy 169.254.0.0/16'; \
+		echo 'RemoteIPTrustedProxy 127.0.0.0/8'; \
+	} > /etc/apache2/conf-available/remoteip.conf; \
+	a2enconf remoteip; \
+# https://github.com/docker-library/wordpress/issues/383#issuecomment-507886512
+# (replace all instances of "%h" with "%a" in LogFormat)
+	find /etc/apache2 -name '*.conf' -exec sed -ri 's/([[:space:]]*LogFormat[[:space:]]+"[^"]*)%h([^"]*")/\1%a\2/g' '{}' +
 
 VOLUME /var/www/html
 

--- a/php7.3/apache/Dockerfile
+++ b/php7.3/apache/Dockerfile
@@ -63,15 +63,24 @@ RUN { \
 		echo 'html_errors = Off'; \
 	} > /usr/local/etc/php/conf.d/error-logging.ini
 
-RUN a2enmod rewrite expires remoteip
-
-RUN { \
-        echo 'RemoteIPHeader X-Forwarded-For' ; \
-        echo 'RemoteIPTrustedProxy 10.0.0.0/8' ; \
-        echo 'RemoteIPTrustedProxy 172.16.0.0/12' ; \
-        echo 'RemoteIPTrustedProxy 192.168.0.0/16' ; \
-    } > /etc/apache2/conf-available/remoteip.conf ; \
-    a2enconf remoteip
+RUN set -eux; \
+	a2enmod rewrite expires; \
+	\
+# https://httpd.apache.org/docs/2.4/mod/mod_remoteip.html
+	a2enmod remoteip; \
+	{ \
+		echo 'RemoteIPHeader X-Forwarded-For'; \
+# these IP ranges are reserved for "private" use and should thus *usually* be safe inside Docker
+		echo 'RemoteIPTrustedProxy 10.0.0.0/8'; \
+		echo 'RemoteIPTrustedProxy 172.16.0.0/12'; \
+		echo 'RemoteIPTrustedProxy 192.168.0.0/16'; \
+		echo 'RemoteIPTrustedProxy 169.254.0.0/16'; \
+		echo 'RemoteIPTrustedProxy 127.0.0.0/8'; \
+	} > /etc/apache2/conf-available/remoteip.conf; \
+	a2enconf remoteip; \
+# https://github.com/docker-library/wordpress/issues/383#issuecomment-507886512
+# (replace all instances of "%h" with "%a" in LogFormat)
+	find /etc/apache2 -name '*.conf' -exec sed -ri 's/([[:space:]]*LogFormat[[:space:]]+"[^"]*)%h([^"]*")/\1%a\2/g' '{}' +
 
 VOLUME /var/www/html
 

--- a/php7.3/apache/Dockerfile
+++ b/php7.3/apache/Dockerfile
@@ -63,7 +63,15 @@ RUN { \
 		echo 'html_errors = Off'; \
 	} > /usr/local/etc/php/conf.d/error-logging.ini
 
-RUN a2enmod rewrite expires
+RUN a2enmod rewrite expires remoteip
+
+RUN { \
+        echo 'RemoteIPHeader X-Forwarded-For' ; \
+        echo 'RemoteIPTrustedProxy 10.0.0.0/8' ; \
+        echo 'RemoteIPTrustedProxy 172.16.0.0/12' ; \
+        echo 'RemoteIPTrustedProxy 192.168.0.0/16' ; \
+    } > /etc/apache2/conf-available/remoteip.conf ; \
+    a2enconf remoteip
 
 VOLUME /var/www/html
 

--- a/update.sh
+++ b/update.sh
@@ -22,10 +22,7 @@ cliSha512="$(curl -fsSL "https://github.com/wp-cli/wp-cli/releases/download/v${c
 echo "$current (CLI $cliVersion)"
 
 declare -A variantExtras=(
-	[apache]='\nRUN a2enmod rewrite expires\n'
-	[fpm]=''
-	[fpm-alpine]=''
-	[cli]='' # unused
+	[apache]="$(< apache-extras.template)"
 )
 declare -A variantCmds=(
 	[apache]='apache2-foreground'
@@ -40,6 +37,10 @@ declare -A variantBases=(
 	[cli]='cli'
 )
 
+sed_escape_rhs() {
+	sed -e 's/[\/&]/\\&/g; $!a\'$'\n''\\n' <<<"$*" | tr -d '\n'
+}
+
 travisEnv=
 for phpVersion in "${phpVersions[@]}"; do
 	phpVersionDir="$phpVersion"
@@ -49,7 +50,10 @@ for phpVersion in "${phpVersions[@]}"; do
 		dir="$phpVersionDir/$variant"
 		mkdir -p "$dir"
 
-		extras="${variantExtras[$variant]}"
+		extras="${variantExtras[$variant]:-}"
+		if [ -n "$extras" ]; then
+			extras=$'\n'"$extras"$'\n'
+		fi
 		cmd="${variantCmds[$variant]}"
 		base="${variantBases[$variant]}"
 
@@ -65,7 +69,7 @@ for phpVersion in "${phpVersions[@]}"; do
 			-e 's!%%VARIANT%%!'"$variant"'!g' \
 			-e 's!%%WORDPRESS_CLI_VERSION%%!'"$cliVersion"'!g' \
 			-e 's!%%WORDPRESS_CLI_SHA512%%!'"$cliSha512"'!g' \
-			-e 's!%%VARIANT_EXTRAS%%!'"$extras"'!g' \
+			-e 's!%%VARIANT_EXTRAS%%!'"$(sed_escape_rhs "$extras")"'!g' \
 			-e 's!%%CMD%%!'"$cmd"'!g' \
 			"Dockerfile-${base}.template" > "$dir/Dockerfile"
 


### PR DESCRIPTION
It helps to retrieve real client IP forward by the load balancer (or reverse proxy like haproxy or nginx)
It's the recommended way to retrieve client ip from "X-Forwarded-For" header in apache 2.4

Closes #383