### PR TITLE
Add imagemagick to alpine.

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -12,6 +12,7 @@ RUN set -ex; \
 	\
 	apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
+		imagemagick \
 		imagemagick-dev \
 		libjpeg-turbo-dev \
 		libpng-dev \


### PR DESCRIPTION
Imagemagick is not working on `wordpress:fpm-alpine` .

solved run `apk --update add imagemagick`