### PR TITLE
Add "ghostscript" for generating PDF thumbnails

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -1,11 +1,13 @@
 FROM php:%%PHP_VERSION%%-%%VARIANT%%
 
-# docker-entrypoint.sh dependencies
+# persistent dependencies
 RUN apk add --no-cache \
 # in theory, docker-entrypoint.sh is POSIX-compliant, but priority is a working, consistent image
 		bash \
 # BusyBox sed is not sufficient for some of our sed expressions
-		sed
+		sed \
+# Ghostscript is required for rendering PDF previews
+		ghostscript
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -1,5 +1,14 @@
 FROM php:%%PHP_VERSION%%-%%VARIANT%%
 
+# persistent dependencies
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# Ghostscript is required for rendering PDF previews
+		ghostscript \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
 	\

--- a/php7.1/apache/Dockerfile
+++ b/php7.1/apache/Dockerfile
@@ -1,5 +1,14 @@
 FROM php:7.1-apache
 
+# persistent dependencies
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# Ghostscript is required for rendering PDF previews
+		ghostscript \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
 	\

--- a/php7.1/fpm-alpine/Dockerfile
+++ b/php7.1/fpm-alpine/Dockerfile
@@ -1,11 +1,13 @@
 FROM php:7.1-fpm-alpine
 
-# docker-entrypoint.sh dependencies
+# persistent dependencies
 RUN apk add --no-cache \
 # in theory, docker-entrypoint.sh is POSIX-compliant, but priority is a working, consistent image
 		bash \
 # BusyBox sed is not sufficient for some of our sed expressions
-		sed
+		sed \
+# Ghostscript is required for rendering PDF previews
+		ghostscript
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \

--- a/php7.1/fpm/Dockerfile
+++ b/php7.1/fpm/Dockerfile
@@ -1,5 +1,14 @@
 FROM php:7.1-fpm
 
+# persistent dependencies
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# Ghostscript is required for rendering PDF previews
+		ghostscript \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
 	\

--- a/php7.2/apache/Dockerfile
+++ b/php7.2/apache/Dockerfile
@@ -1,5 +1,14 @@
 FROM php:7.2-apache
 
+# persistent dependencies
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# Ghostscript is required for rendering PDF previews
+		ghostscript \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
 	\

--- a/php7.2/fpm-alpine/Dockerfile
+++ b/php7.2/fpm-alpine/Dockerfile
@@ -1,11 +1,13 @@
 FROM php:7.2-fpm-alpine
 
-# docker-entrypoint.sh dependencies
+# persistent dependencies
 RUN apk add --no-cache \
 # in theory, docker-entrypoint.sh is POSIX-compliant, but priority is a working, consistent image
 		bash \
 # BusyBox sed is not sufficient for some of our sed expressions
-		sed
+		sed \
+# Ghostscript is required for rendering PDF previews
+		ghostscript
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \

--- a/php7.2/fpm/Dockerfile
+++ b/php7.2/fpm/Dockerfile
@@ -1,5 +1,14 @@
 FROM php:7.2-fpm
 
+# persistent dependencies
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# Ghostscript is required for rendering PDF previews
+		ghostscript \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
 	\

--- a/php7.3/apache/Dockerfile
+++ b/php7.3/apache/Dockerfile
@@ -1,5 +1,14 @@
 FROM php:7.3-apache
 
+# persistent dependencies
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# Ghostscript is required for rendering PDF previews
+		ghostscript \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
 	\

--- a/php7.3/fpm-alpine/Dockerfile
+++ b/php7.3/fpm-alpine/Dockerfile
@@ -1,11 +1,13 @@
 FROM php:7.3-fpm-alpine
 
-# docker-entrypoint.sh dependencies
+# persistent dependencies
 RUN apk add --no-cache \
 # in theory, docker-entrypoint.sh is POSIX-compliant, but priority is a working, consistent image
 		bash \
 # BusyBox sed is not sufficient for some of our sed expressions
-		sed
+		sed \
+# Ghostscript is required for rendering PDF previews
+		ghostscript
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \

--- a/php7.3/fpm/Dockerfile
+++ b/php7.3/fpm/Dockerfile
@@ -1,5 +1,14 @@
 FROM php:7.3-fpm
 
+# persistent dependencies
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# Ghostscript is required for rendering PDF previews
+		ghostscript \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
 	\


### PR DESCRIPTION
When uploading PDFs to the Media Library, WordPress (since 4.7) will generate a thumbnail via ImageMagick.

We have ImageMagick, but without Ghostscript installed it is unable to process PDF files (since it uses Ghostscript to render PDFs into images that it can then handle directly).

Fixes #429