### PR TITLE
[apache] disable \'Require local\' IP for server-status, as this feature has m…

### DIFF
--- a/apache-extras.template
+++ b/apache-extras.template
@@ -1,4 +1,5 @@
 RUN set -eux; \
+        sed -i 's/Require\ local/#Require\ local/g' ${APACHE_CONFDIR}/mods-available/status.conf; \
 	a2enmod rewrite expires; \
 	\
 # https://httpd.apache.org/docs/2.4/mod/mod_remoteip.html


### PR DESCRIPTION
## [apache] disable \'Require local\' IP for mod_status / server-status, 

As this (default installed module) feature has many use cases outside of `apachectl status`\, i.e. when deploying wordpress on apache in Google Cloud Platform or Google Kubernetes Engine, one needs a 200-OK returning endpoint for a `readinessProbe` that would also be used for a gclb load balancer health check.

Ref;

https://httpd.apache.org/docs/current/mod/mod_status.html