### PR TITLE
Make already existing files owned by current user

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -46,9 +46,9 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 	fi
 
 	if [ ! -e index.php ] && [ ! -e wp-includes/version.php ]; then
-		# if the directory exists and WordPress doesn't appear to be installed AND the permissions of it are root:root, let's chown it (likely a Docker-created directory)
-		if [ "$(id -u)" = '0' ] && [ "$(stat -c '%u:%g' .)" = '0:0' ]; then
-			chown "$user:$group" .
+		# if the directory exists and WordPress doesn't appear to be installed, let's chown it (likely a Docker-created directory)
+		if [ "$(id -u)" = '0' ]; then
+			chown -R "$user:$group" .
 		fi
 
 		echo >&2 "WordPress not found in $PWD - copying now..."

--- a/php7.2/apache/docker-entrypoint.sh
+++ b/php7.2/apache/docker-entrypoint.sh
@@ -46,9 +46,9 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 	fi
 
 	if [ ! -e index.php ] && [ ! -e wp-includes/version.php ]; then
-		# if the directory exists and WordPress doesn't appear to be installed AND the permissions of it are root:root, let's chown it (likely a Docker-created directory)
-		if [ "$(id -u)" = '0' ] && [ "$(stat -c '%u:%g' .)" = '0:0' ]; then
-			chown "$user:$group" .
+		# if the directory exists and WordPress doesn't appear to be installed, let's chown it (likely a Docker-created directory) of it are root:root, let's chown it (likely a Docker-created directory)
+		if [ "$(id -u)" = '0' ]; then
+			chown -R "$user:$group" .
 		fi
 
 		echo >&2 "WordPress not found in $PWD - copying now..."

--- a/php7.2/fpm-alpine/docker-entrypoint.sh
+++ b/php7.2/fpm-alpine/docker-entrypoint.sh
@@ -46,9 +46,9 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 	fi
 
 	if [ ! -e index.php ] && [ ! -e wp-includes/version.php ]; then
-		# if the directory exists and WordPress doesn't appear to be installed AND the permissions of it are root:root, let's chown it (likely a Docker-created directory)
-		if [ "$(id -u)" = '0' ] && [ "$(stat -c '%u:%g' .)" = '0:0' ]; then
-			chown "$user:$group" .
+		# if the directory exists and WordPress doesn't appear to be installed, let's chown it (likely a Docker-created directory) of it are root:root, let's chown it (likely a Docker-created directory)
+		if [ "$(id -u)" = '0' ]; then
+			chown -R "$user:$group" .
 		fi
 
 		echo >&2 "WordPress not found in $PWD - copying now..."

--- a/php7.2/fpm/docker-entrypoint.sh
+++ b/php7.2/fpm/docker-entrypoint.sh
@@ -46,9 +46,9 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 	fi
 
 	if [ ! -e index.php ] && [ ! -e wp-includes/version.php ]; then
-		# if the directory exists and WordPress doesn't appear to be installed AND the permissions of it are root:root, let's chown it (likely a Docker-created directory)
-		if [ "$(id -u)" = '0' ] && [ "$(stat -c '%u:%g' .)" = '0:0' ]; then
-			chown "$user:$group" .
+		# if the directory exists and WordPress doesn't appear to be installed, let's chown it (likely a Docker-created directory) of it are root:root, let's chown it (likely a Docker-created directory)
+		if [ "$(id -u)" = '0' ]; then
+			chown -R "$user:$group" .
 		fi
 
 		echo >&2 "WordPress not found in $PWD - copying now..."

--- a/php7.3/apache/docker-entrypoint.sh
+++ b/php7.3/apache/docker-entrypoint.sh
@@ -46,9 +46,9 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 	fi
 
 	if [ ! -e index.php ] && [ ! -e wp-includes/version.php ]; then
-		# if the directory exists and WordPress doesn't appear to be installed AND the permissions of it are root:root, let's chown it (likely a Docker-created directory)
-		if [ "$(id -u)" = '0' ] && [ "$(stat -c '%u:%g' .)" = '0:0' ]; then
-			chown "$user:$group" .
+		# if the directory exists and WordPress doesn't appear to be installed, let's chown it (likely a Docker-created directory) of it are root:root, let's chown it (likely a Docker-created directory)
+		if [ "$(id -u)" = '0' ]; then
+			chown -R "$user:$group" .
 		fi
 
 		echo >&2 "WordPress not found in $PWD - copying now..."

--- a/php7.3/fpm-alpine/docker-entrypoint.sh
+++ b/php7.3/fpm-alpine/docker-entrypoint.sh
@@ -46,9 +46,9 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 	fi
 
 	if [ ! -e index.php ] && [ ! -e wp-includes/version.php ]; then
-		# if the directory exists and WordPress doesn't appear to be installed AND the permissions of it are root:root, let's chown it (likely a Docker-created directory)
-		if [ "$(id -u)" = '0' ] && [ "$(stat -c '%u:%g' .)" = '0:0' ]; then
-			chown "$user:$group" .
+		# if the directory exists and WordPress doesn't appear to be installed, let's chown it (likely a Docker-created directory) of it are root:root, let's chown it (likely a Docker-created directory)
+		if [ "$(id -u)" = '0' ]; then
+			chown -R "$user:$group" .
 		fi
 
 		echo >&2 "WordPress not found in $PWD - copying now..."

--- a/php7.3/fpm/docker-entrypoint.sh
+++ b/php7.3/fpm/docker-entrypoint.sh
@@ -46,9 +46,9 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 	fi
 
 	if [ ! -e index.php ] && [ ! -e wp-includes/version.php ]; then
-		# if the directory exists and WordPress doesn't appear to be installed AND the permissions of it are root:root, let's chown it (likely a Docker-created directory)
-		if [ "$(id -u)" = '0' ] && [ "$(stat -c '%u:%g' .)" = '0:0' ]; then
-			chown "$user:$group" .
+		# if the directory exists and WordPress doesn't appear to be installed, let's chown it (likely a Docker-created directory) of it are root:root, let's chown it (likely a Docker-created directory)
+		if [ "$(id -u)" = '0' ]; then
+			chown -R "$user:$group" .
 		fi
 
 		echo >&2 "WordPress not found in $PWD - copying now..."

--- a/php7.4/apache/docker-entrypoint.sh
+++ b/php7.4/apache/docker-entrypoint.sh
@@ -46,9 +46,9 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 	fi
 
 	if [ ! -e index.php ] && [ ! -e wp-includes/version.php ]; then
-		# if the directory exists and WordPress doesn't appear to be installed AND the permissions of it are root:root, let's chown it (likely a Docker-created directory)
-		if [ "$(id -u)" = '0' ] && [ "$(stat -c '%u:%g' .)" = '0:0' ]; then
-			chown "$user:$group" .
+		# if the directory exists and WordPress doesn't appear to be installed, let's chown it (likely a Docker-created directory) of it are root:root, let's chown it (likely a Docker-created directory)
+		if [ "$(id -u)" = '0' ]; then
+			chown -R "$user:$group" .
 		fi
 
 		echo >&2 "WordPress not found in $PWD - copying now..."

--- a/php7.4/fpm-alpine/docker-entrypoint.sh
+++ b/php7.4/fpm-alpine/docker-entrypoint.sh
@@ -46,9 +46,9 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 	fi
 
 	if [ ! -e index.php ] && [ ! -e wp-includes/version.php ]; then
-		# if the directory exists and WordPress doesn't appear to be installed AND the permissions of it are root:root, let's chown it (likely a Docker-created directory)
-		if [ "$(id -u)" = '0' ] && [ "$(stat -c '%u:%g' .)" = '0:0' ]; then
-			chown "$user:$group" .
+		# if the directory exists and WordPress doesn't appear to be installed, let's chown it (likely a Docker-created directory) of it are root:root, let's chown it (likely a Docker-created directory)
+		if [ "$(id -u)" = '0' ]; then
+			chown -R "$user:$group" .
 		fi
 
 		echo >&2 "WordPress not found in $PWD - copying now..."

--- a/php7.4/fpm/docker-entrypoint.sh
+++ b/php7.4/fpm/docker-entrypoint.sh
@@ -46,9 +46,9 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 	fi
 
 	if [ ! -e index.php ] && [ ! -e wp-includes/version.php ]; then
-		# if the directory exists and WordPress doesn't appear to be installed AND the permissions of it are root:root, let's chown it (likely a Docker-created directory)
-		if [ "$(id -u)" = '0' ] && [ "$(stat -c '%u:%g' .)" = '0:0' ]; then
-			chown "$user:$group" .
+		# if the directory exists and WordPress doesn't appear to be installed, let's chown it (likely a Docker-created directory) of it are root:root, let's chown it (likely a Docker-created directory)
+		if [ "$(id -u)" = '0' ]; then
+			chown -R "$user:$group" .
 		fi
 
 		echo >&2 "WordPress not found in $PWD - copying now..."


### PR DESCRIPTION
This PR makes all already existing files in the `/var/www/html` directory owned by the `www-data` user instead of `root`.

## Issue description

It is a problem that has been mentioned several times here on GitHub (see #436 and #358) and on [StackOverflow](https://stackoverflow.com/questions/55747066/how-to-fix-file-permissions-on-wp-content-with-official-wordpress-image-for-dock).

The problem happens for example when sharing a folder into the *wp-content* WordPress folder, like in this Docker Compose example:

```yaml
services:
  wordpress:
    image: wordpress:5.3-php7.4-fpm-alpine
    volumes:
      - wordpress_data:/var/www/html
      - ./themes/my-theme:/var/www/html/wp-content/themes/my-theme

volumes:
  wordpress_data: {}
```

Running these commands:

    docker-compose up -d
    docker-compose exec wordpress ls -al /var/www/html/

Will result in a list like:

    -rw-r--r--    1 www-data www-data      2898 Jan  8  2019 wp-config-sample.php
    drwxr-xr-x    4 root     root          4096 Feb 28 20:33 wp-content
    -rw-r--r--    1 www-data www-data      3955 Oct 10 22:52 wp-cron.php

The *wp-content* (which has been created by Docker when sharing the volumes) folder belongs to the `root` user instead of the `www-data` user.


## Why the issue is happening

Docker creates the shared folder *before* WordPress is installed into the `/var/www/html` folder.

The `docker-entrypoint.sh` script is executed *after* and checks whether the `/var/www/html` folder already exists, and if so, fixes user ownership of it:

```bash
if [ "$(id -u)" = '0' ] && [ "$(stat -c '%u:%g' .)" = '0:0' ]; then
  chown "$user:$group" .
fi
```

The test is not relevant anymore. Since PHP 7.x, the Docker images create a `/var/www/html` folder that already belongs to `www-data`, meaning that the condition will never be met. You can check this by running this:

    docker run --rm php:7.4-fpm-alpine ls -al /var/www

Result:

    drwxrwxrwx    2 www-data www-data      4096 Oct 21 20:38 html

Same command for PHP 5.6:

    docker run --rm php:5.6-fpm-alpine ls -al /var/www
    
Result:

    drwxr-xr-x    2 root     root          4096 Jan 31  2019 html


## Changes made

The following changes were made:

* Do not check for `/var/www/html` *root* ownership.
* Change ownership of all existing files.


