### PR TITLE
fix imagick on alpine

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -7,7 +7,9 @@ RUN apk add --no-cache \
 # BusyBox sed is not sufficient for some of our sed expressions
 		sed \
 # Ghostscript is required for rendering PDF previews
-		ghostscript
+		ghostscript \
+# Alpine package for "imagemagick" contains ~120 .so files, see: https://github.com/docker-library/wordpress/pull/497
+		imagemagick
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
@@ -39,7 +41,7 @@ RUN set -ex; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --virtual .wordpress-phpexts-rundeps $runDeps imagemagick; \
+	apk add --virtual .wordpress-phpexts-rundeps $runDeps; \
 	apk del .build-deps
 
 # set recommended PHP.ini settings

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -39,7 +39,7 @@ RUN set -ex; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --virtual .wordpress-phpexts-rundeps $runDeps; \
+	apk add --virtual .wordpress-phpexts-rundeps $runDeps imagemagick; \
 	apk del .build-deps
 
 # set recommended PHP.ini settings

--- a/php7.2/fpm-alpine/Dockerfile
+++ b/php7.2/fpm-alpine/Dockerfile
@@ -38,7 +38,7 @@ RUN set -ex; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --virtual .wordpress-phpexts-rundeps $runDeps; \
+	apk add --virtual .wordpress-phpexts-rundeps $runDeps imagemagick; \
 	apk del .build-deps
 
 # set recommended PHP.ini settings

--- a/php7.2/fpm-alpine/Dockerfile
+++ b/php7.2/fpm-alpine/Dockerfile
@@ -7,7 +7,9 @@ RUN apk add --no-cache \
 # BusyBox sed is not sufficient for some of our sed expressions
 		sed \
 # Ghostscript is required for rendering PDF previews
-		ghostscript
+		ghostscript \
+# Alpine package for "imagemagick" contains ~120 .so files, see: https://github.com/docker-library/wordpress/pull/497
+		imagemagick
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
@@ -38,7 +40,7 @@ RUN set -ex; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --virtual .wordpress-phpexts-rundeps $runDeps imagemagick; \
+	apk add --virtual .wordpress-phpexts-rundeps $runDeps; \
 	apk del .build-deps
 
 # set recommended PHP.ini settings

--- a/php7.3/fpm-alpine/Dockerfile
+++ b/php7.3/fpm-alpine/Dockerfile
@@ -7,7 +7,9 @@ RUN apk add --no-cache \
 # BusyBox sed is not sufficient for some of our sed expressions
 		sed \
 # Ghostscript is required for rendering PDF previews
-		ghostscript
+		ghostscript \
+# Alpine package for "imagemagick" contains ~120 .so files, see: https://github.com/docker-library/wordpress/pull/497
+		imagemagick
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
@@ -39,7 +41,7 @@ RUN set -ex; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --virtual .wordpress-phpexts-rundeps $runDeps imagemagick; \
+	apk add --virtual .wordpress-phpexts-rundeps $runDeps; \
 	apk del .build-deps
 
 # set recommended PHP.ini settings

--- a/php7.3/fpm-alpine/Dockerfile
+++ b/php7.3/fpm-alpine/Dockerfile
@@ -39,7 +39,7 @@ RUN set -ex; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --virtual .wordpress-phpexts-rundeps $runDeps; \
+	apk add --virtual .wordpress-phpexts-rundeps $runDeps imagemagick; \
 	apk del .build-deps
 
 # set recommended PHP.ini settings

--- a/php7.4/fpm-alpine/Dockerfile
+++ b/php7.4/fpm-alpine/Dockerfile
@@ -7,7 +7,9 @@ RUN apk add --no-cache \
 # BusyBox sed is not sufficient for some of our sed expressions
 		sed \
 # Ghostscript is required for rendering PDF previews
-		ghostscript
+		ghostscript \
+# Alpine package for "imagemagick" contains ~120 .so files, see: https://github.com/docker-library/wordpress/pull/497
+		imagemagick
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
@@ -39,7 +41,7 @@ RUN set -ex; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --virtual .wordpress-phpexts-rundeps $runDeps imagemagick; \
+	apk add --virtual .wordpress-phpexts-rundeps $runDeps; \
 	apk del .build-deps
 
 # set recommended PHP.ini settings

--- a/php7.4/fpm-alpine/Dockerfile
+++ b/php7.4/fpm-alpine/Dockerfile
@@ -39,7 +39,7 @@ RUN set -ex; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --virtual .wordpress-phpexts-rundeps $runDeps; \
+	apk add --virtual .wordpress-phpexts-rundeps $runDeps imagemagick; \
 	apk del .build-deps
 
 # set recommended PHP.ini settings


### PR DESCRIPTION
Currently alpine images have a broken imagick extension. The extension does not rely only on imagick libraries but a bunch of other libraries (libjpeg, libpng, etc.).

See:

* https://github.com/docker-library/php/issues/105#issuecomment-249716758
* https://github.com/thephpleague/glide/issues/237

Unless this was done on purpose to keep the base image size small? I would then either leave imagick out completely or add better documentation to this behaviour.