### PR TITLE
Pre-create "wp-content" (and subdirectories) with wide permissions for users who bind-mount directly into them

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -68,7 +68,6 @@ RUN { \
 		echo 'html_errors = Off'; \
 	} > /usr/local/etc/php/conf.d/error-logging.ini
 %%VARIANT_EXTRAS%%
-VOLUME /var/www/html
 
 ENV WORDPRESS_VERSION %%WORDPRESS_VERSION%%
 ENV WORDPRESS_SHA1 %%WORDPRESS_SHA1%%
@@ -79,7 +78,17 @@ RUN set -ex; \
 # upstream tarballs include ./wordpress/ so this gives us /usr/src/wordpress
 	tar -xzf wordpress.tar.gz -C /usr/src/; \
 	rm wordpress.tar.gz; \
-	chown -R www-data:www-data /usr/src/wordpress
+	chown -R www-data:www-data /usr/src/wordpress; \
+# pre-create wp-content (and single-level children) for folks who want to bind-mount themes, etc so permissions are pre-created properly instead of root:root
+	mkdir wp-content; \
+	for dir in /usr/src/wordpress/wp-content/*/; do \
+		dir="$(basename "${dir%/}")"; \
+		mkdir "wp-content/$dir"; \
+	done; \
+	chown -R www-data:www-data wp-content; \
+	chmod -R 777 wp-content
+
+VOLUME /var/www/html
 
 COPY docker-entrypoint.sh /usr/local/bin/
 

--- a/Dockerfile-cli.template
+++ b/Dockerfile-cli.template
@@ -60,7 +60,6 @@ RUN set -ex; \
 	mkdir -p /var/www/html; \
 	chown -R www-data:www-data /var/www/html
 WORKDIR /var/www/html
-VOLUME /var/www/html
 
 # https://make.wordpress.org/cli/2018/05/31/gpg-signature-change/
 # pub   rsa2048 2018-05-31 [SC]
@@ -92,6 +91,8 @@ RUN set -ex; \
 	apk del .fetch-deps; \
 	\
 	wp --allow-root --version
+
+VOLUME /var/www/html
 
 COPY docker-entrypoint.sh /usr/local/bin/
 

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -73,7 +73,6 @@ RUN { \
 		echo 'html_errors = Off'; \
 	} > /usr/local/etc/php/conf.d/error-logging.ini
 %%VARIANT_EXTRAS%%
-VOLUME /var/www/html
 
 ENV WORDPRESS_VERSION %%WORDPRESS_VERSION%%
 ENV WORDPRESS_SHA1 %%WORDPRESS_SHA1%%
@@ -84,7 +83,17 @@ RUN set -ex; \
 # upstream tarballs include ./wordpress/ so this gives us /usr/src/wordpress
 	tar -xzf wordpress.tar.gz -C /usr/src/; \
 	rm wordpress.tar.gz; \
-	chown -R www-data:www-data /usr/src/wordpress
+	chown -R www-data:www-data /usr/src/wordpress; \
+# pre-create wp-content (and single-level children) for folks who want to bind-mount themes, etc so permissions are pre-created properly instead of root:root
+	mkdir wp-content; \
+	for dir in /usr/src/wordpress/wp-content/*/; do \
+		dir="$(basename "${dir%/}")"; \
+		mkdir "wp-content/$dir"; \
+	done; \
+	chown -R www-data:www-data wp-content; \
+	chmod -R 777 wp-content
+
+VOLUME /var/www/html
 
 COPY docker-entrypoint.sh /usr/local/bin/
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -52,7 +52,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		fi
 
 		echo >&2 "WordPress not found in $PWD - copying now..."
-		if [ -n "$(ls -A)" ]; then
+		if [ -n "$(find -mindepth 1 -maxdepth 1 -not -name wp-content)" ]; then
 			echo >&2 "WARNING: $PWD is not empty! (copying anyhow)"
 		fi
 		sourceTarArgs=(

--- a/php7.2/apache/Dockerfile
+++ b/php7.2/apache/Dockerfile
@@ -91,7 +91,6 @@ RUN set -eux; \
 # (replace all instances of "%h" with "%a" in LogFormat)
 	find /etc/apache2 -type f -name '*.conf' -exec sed -ri 's/([[:space:]]*LogFormat[[:space:]]+"[^"]*)%h([^"]*")/\1%a\2/g' '{}' +
 
-VOLUME /var/www/html
 
 ENV WORDPRESS_VERSION 5.4.1
 ENV WORDPRESS_SHA1 9800c231828eb5cd76ba0b8aa6c1a74dfca2daff
@@ -102,7 +101,17 @@ RUN set -ex; \
 # upstream tarballs include ./wordpress/ so this gives us /usr/src/wordpress
 	tar -xzf wordpress.tar.gz -C /usr/src/; \
 	rm wordpress.tar.gz; \
-	chown -R www-data:www-data /usr/src/wordpress
+	chown -R www-data:www-data /usr/src/wordpress; \
+# pre-create wp-content (and single-level children) for folks who want to bind-mount themes, etc so permissions are pre-created properly instead of root:root
+	mkdir wp-content; \
+	for dir in /usr/src/wordpress/wp-content/*/; do \
+		dir="$(basename "${dir%/}")"; \
+		mkdir "wp-content/$dir"; \
+	done; \
+	chown -R www-data:www-data wp-content; \
+	chmod -R 777 wp-content
+
+VOLUME /var/www/html
 
 COPY docker-entrypoint.sh /usr/local/bin/
 

--- a/php7.2/apache/docker-entrypoint.sh
+++ b/php7.2/apache/docker-entrypoint.sh
@@ -52,7 +52,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		fi
 
 		echo >&2 "WordPress not found in $PWD - copying now..."
-		if [ -n "$(ls -A)" ]; then
+		if [ -n "$(find -mindepth 1 -maxdepth 1 -not -name wp-content)" ]; then
 			echo >&2 "WARNING: $PWD is not empty! (copying anyhow)"
 		fi
 		sourceTarArgs=(

--- a/php7.2/cli/Dockerfile
+++ b/php7.2/cli/Dockerfile
@@ -59,7 +59,6 @@ RUN set -ex; \
 	mkdir -p /var/www/html; \
 	chown -R www-data:www-data /var/www/html
 WORKDIR /var/www/html
-VOLUME /var/www/html
 
 # https://make.wordpress.org/cli/2018/05/31/gpg-signature-change/
 # pub   rsa2048 2018-05-31 [SC]
@@ -91,6 +90,8 @@ RUN set -ex; \
 	apk del .fetch-deps; \
 	\
 	wp --allow-root --version
+
+VOLUME /var/www/html
 
 COPY docker-entrypoint.sh /usr/local/bin/
 

--- a/php7.2/fpm-alpine/Dockerfile
+++ b/php7.2/fpm-alpine/Dockerfile
@@ -67,7 +67,6 @@ RUN { \
 		echo 'html_errors = Off'; \
 	} > /usr/local/etc/php/conf.d/error-logging.ini
 
-VOLUME /var/www/html
 
 ENV WORDPRESS_VERSION 5.4.1
 ENV WORDPRESS_SHA1 9800c231828eb5cd76ba0b8aa6c1a74dfca2daff
@@ -78,7 +77,17 @@ RUN set -ex; \
 # upstream tarballs include ./wordpress/ so this gives us /usr/src/wordpress
 	tar -xzf wordpress.tar.gz -C /usr/src/; \
 	rm wordpress.tar.gz; \
-	chown -R www-data:www-data /usr/src/wordpress
+	chown -R www-data:www-data /usr/src/wordpress; \
+# pre-create wp-content (and single-level children) for folks who want to bind-mount themes, etc so permissions are pre-created properly instead of root:root
+	mkdir wp-content; \
+	for dir in /usr/src/wordpress/wp-content/*/; do \
+		dir="$(basename "${dir%/}")"; \
+		mkdir "wp-content/$dir"; \
+	done; \
+	chown -R www-data:www-data wp-content; \
+	chmod -R 777 wp-content
+
+VOLUME /var/www/html
 
 COPY docker-entrypoint.sh /usr/local/bin/
 

--- a/php7.2/fpm-alpine/docker-entrypoint.sh
+++ b/php7.2/fpm-alpine/docker-entrypoint.sh
@@ -52,7 +52,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		fi
 
 		echo >&2 "WordPress not found in $PWD - copying now..."
-		if [ -n "$(ls -A)" ]; then
+		if [ -n "$(find -mindepth 1 -maxdepth 1 -not -name wp-content)" ]; then
 			echo >&2 "WARNING: $PWD is not empty! (copying anyhow)"
 		fi
 		sourceTarArgs=(

--- a/php7.2/fpm/Dockerfile
+++ b/php7.2/fpm/Dockerfile
@@ -72,7 +72,6 @@ RUN { \
 		echo 'html_errors = Off'; \
 	} > /usr/local/etc/php/conf.d/error-logging.ini
 
-VOLUME /var/www/html
 
 ENV WORDPRESS_VERSION 5.4.1
 ENV WORDPRESS_SHA1 9800c231828eb5cd76ba0b8aa6c1a74dfca2daff
@@ -83,7 +82,17 @@ RUN set -ex; \
 # upstream tarballs include ./wordpress/ so this gives us /usr/src/wordpress
 	tar -xzf wordpress.tar.gz -C /usr/src/; \
 	rm wordpress.tar.gz; \
-	chown -R www-data:www-data /usr/src/wordpress
+	chown -R www-data:www-data /usr/src/wordpress; \
+# pre-create wp-content (and single-level children) for folks who want to bind-mount themes, etc so permissions are pre-created properly instead of root:root
+	mkdir wp-content; \
+	for dir in /usr/src/wordpress/wp-content/*/; do \
+		dir="$(basename "${dir%/}")"; \
+		mkdir "wp-content/$dir"; \
+	done; \
+	chown -R www-data:www-data wp-content; \
+	chmod -R 777 wp-content
+
+VOLUME /var/www/html
 
 COPY docker-entrypoint.sh /usr/local/bin/
 

--- a/php7.2/fpm/docker-entrypoint.sh
+++ b/php7.2/fpm/docker-entrypoint.sh
@@ -52,7 +52,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		fi
 
 		echo >&2 "WordPress not found in $PWD - copying now..."
-		if [ -n "$(ls -A)" ]; then
+		if [ -n "$(find -mindepth 1 -maxdepth 1 -not -name wp-content)" ]; then
 			echo >&2 "WARNING: $PWD is not empty! (copying anyhow)"
 		fi
 		sourceTarArgs=(

--- a/php7.3/apache/Dockerfile
+++ b/php7.3/apache/Dockerfile
@@ -92,7 +92,6 @@ RUN set -eux; \
 # (replace all instances of "%h" with "%a" in LogFormat)
 	find /etc/apache2 -type f -name '*.conf' -exec sed -ri 's/([[:space:]]*LogFormat[[:space:]]+"[^"]*)%h([^"]*")/\1%a\2/g' '{}' +
 
-VOLUME /var/www/html
 
 ENV WORDPRESS_VERSION 5.4.1
 ENV WORDPRESS_SHA1 9800c231828eb5cd76ba0b8aa6c1a74dfca2daff
@@ -103,7 +102,17 @@ RUN set -ex; \
 # upstream tarballs include ./wordpress/ so this gives us /usr/src/wordpress
 	tar -xzf wordpress.tar.gz -C /usr/src/; \
 	rm wordpress.tar.gz; \
-	chown -R www-data:www-data /usr/src/wordpress
+	chown -R www-data:www-data /usr/src/wordpress; \
+# pre-create wp-content (and single-level children) for folks who want to bind-mount themes, etc so permissions are pre-created properly instead of root:root
+	mkdir wp-content; \
+	for dir in /usr/src/wordpress/wp-content/*/; do \
+		dir="$(basename "${dir%/}")"; \
+		mkdir "wp-content/$dir"; \
+	done; \
+	chown -R www-data:www-data wp-content; \
+	chmod -R 777 wp-content
+
+VOLUME /var/www/html
 
 COPY docker-entrypoint.sh /usr/local/bin/
 

--- a/php7.3/apache/docker-entrypoint.sh
+++ b/php7.3/apache/docker-entrypoint.sh
@@ -52,7 +52,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		fi
 
 		echo >&2 "WordPress not found in $PWD - copying now..."
-		if [ -n "$(ls -A)" ]; then
+		if [ -n "$(find -mindepth 1 -maxdepth 1 -not -name wp-content)" ]; then
 			echo >&2 "WARNING: $PWD is not empty! (copying anyhow)"
 		fi
 		sourceTarArgs=(

--- a/php7.3/cli/Dockerfile
+++ b/php7.3/cli/Dockerfile
@@ -60,7 +60,6 @@ RUN set -ex; \
 	mkdir -p /var/www/html; \
 	chown -R www-data:www-data /var/www/html
 WORKDIR /var/www/html
-VOLUME /var/www/html
 
 # https://make.wordpress.org/cli/2018/05/31/gpg-signature-change/
 # pub   rsa2048 2018-05-31 [SC]
@@ -92,6 +91,8 @@ RUN set -ex; \
 	apk del .fetch-deps; \
 	\
 	wp --allow-root --version
+
+VOLUME /var/www/html
 
 COPY docker-entrypoint.sh /usr/local/bin/
 

--- a/php7.3/fpm-alpine/Dockerfile
+++ b/php7.3/fpm-alpine/Dockerfile
@@ -68,7 +68,6 @@ RUN { \
 		echo 'html_errors = Off'; \
 	} > /usr/local/etc/php/conf.d/error-logging.ini
 
-VOLUME /var/www/html
 
 ENV WORDPRESS_VERSION 5.4.1
 ENV WORDPRESS_SHA1 9800c231828eb5cd76ba0b8aa6c1a74dfca2daff
@@ -79,7 +78,17 @@ RUN set -ex; \
 # upstream tarballs include ./wordpress/ so this gives us /usr/src/wordpress
 	tar -xzf wordpress.tar.gz -C /usr/src/; \
 	rm wordpress.tar.gz; \
-	chown -R www-data:www-data /usr/src/wordpress
+	chown -R www-data:www-data /usr/src/wordpress; \
+# pre-create wp-content (and single-level children) for folks who want to bind-mount themes, etc so permissions are pre-created properly instead of root:root
+	mkdir wp-content; \
+	for dir in /usr/src/wordpress/wp-content/*/; do \
+		dir="$(basename "${dir%/}")"; \
+		mkdir "wp-content/$dir"; \
+	done; \
+	chown -R www-data:www-data wp-content; \
+	chmod -R 777 wp-content
+
+VOLUME /var/www/html
 
 COPY docker-entrypoint.sh /usr/local/bin/
 

--- a/php7.3/fpm-alpine/docker-entrypoint.sh
+++ b/php7.3/fpm-alpine/docker-entrypoint.sh
@@ -52,7 +52,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		fi
 
 		echo >&2 "WordPress not found in $PWD - copying now..."
-		if [ -n "$(ls -A)" ]; then
+		if [ -n "$(find -mindepth 1 -maxdepth 1 -not -name wp-content)" ]; then
 			echo >&2 "WARNING: $PWD is not empty! (copying anyhow)"
 		fi
 		sourceTarArgs=(

--- a/php7.3/fpm/Dockerfile
+++ b/php7.3/fpm/Dockerfile
@@ -73,7 +73,6 @@ RUN { \
 		echo 'html_errors = Off'; \
 	} > /usr/local/etc/php/conf.d/error-logging.ini
 
-VOLUME /var/www/html
 
 ENV WORDPRESS_VERSION 5.4.1
 ENV WORDPRESS_SHA1 9800c231828eb5cd76ba0b8aa6c1a74dfca2daff
@@ -84,7 +83,17 @@ RUN set -ex; \
 # upstream tarballs include ./wordpress/ so this gives us /usr/src/wordpress
 	tar -xzf wordpress.tar.gz -C /usr/src/; \
 	rm wordpress.tar.gz; \
-	chown -R www-data:www-data /usr/src/wordpress
+	chown -R www-data:www-data /usr/src/wordpress; \
+# pre-create wp-content (and single-level children) for folks who want to bind-mount themes, etc so permissions are pre-created properly instead of root:root
+	mkdir wp-content; \
+	for dir in /usr/src/wordpress/wp-content/*/; do \
+		dir="$(basename "${dir%/}")"; \
+		mkdir "wp-content/$dir"; \
+	done; \
+	chown -R www-data:www-data wp-content; \
+	chmod -R 777 wp-content
+
+VOLUME /var/www/html
 
 COPY docker-entrypoint.sh /usr/local/bin/
 

--- a/php7.3/fpm/docker-entrypoint.sh
+++ b/php7.3/fpm/docker-entrypoint.sh
@@ -52,7 +52,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		fi
 
 		echo >&2 "WordPress not found in $PWD - copying now..."
-		if [ -n "$(ls -A)" ]; then
+		if [ -n "$(find -mindepth 1 -maxdepth 1 -not -name wp-content)" ]; then
 			echo >&2 "WARNING: $PWD is not empty! (copying anyhow)"
 		fi
 		sourceTarArgs=(

--- a/php7.4/apache/Dockerfile
+++ b/php7.4/apache/Dockerfile
@@ -92,7 +92,6 @@ RUN set -eux; \
 # (replace all instances of "%h" with "%a" in LogFormat)
 	find /etc/apache2 -type f -name '*.conf' -exec sed -ri 's/([[:space:]]*LogFormat[[:space:]]+"[^"]*)%h([^"]*")/\1%a\2/g' '{}' +
 
-VOLUME /var/www/html
 
 ENV WORDPRESS_VERSION 5.4.1
 ENV WORDPRESS_SHA1 9800c231828eb5cd76ba0b8aa6c1a74dfca2daff
@@ -103,7 +102,17 @@ RUN set -ex; \
 # upstream tarballs include ./wordpress/ so this gives us /usr/src/wordpress
 	tar -xzf wordpress.tar.gz -C /usr/src/; \
 	rm wordpress.tar.gz; \
-	chown -R www-data:www-data /usr/src/wordpress
+	chown -R www-data:www-data /usr/src/wordpress; \
+# pre-create wp-content (and single-level children) for folks who want to bind-mount themes, etc so permissions are pre-created properly instead of root:root
+	mkdir wp-content; \
+	for dir in /usr/src/wordpress/wp-content/*/; do \
+		dir="$(basename "${dir%/}")"; \
+		mkdir "wp-content/$dir"; \
+	done; \
+	chown -R www-data:www-data wp-content; \
+	chmod -R 777 wp-content
+
+VOLUME /var/www/html
 
 COPY docker-entrypoint.sh /usr/local/bin/
 

--- a/php7.4/apache/docker-entrypoint.sh
+++ b/php7.4/apache/docker-entrypoint.sh
@@ -52,7 +52,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		fi
 
 		echo >&2 "WordPress not found in $PWD - copying now..."
-		if [ -n "$(ls -A)" ]; then
+		if [ -n "$(find -mindepth 1 -maxdepth 1 -not -name wp-content)" ]; then
 			echo >&2 "WARNING: $PWD is not empty! (copying anyhow)"
 		fi
 		sourceTarArgs=(

--- a/php7.4/cli/Dockerfile
+++ b/php7.4/cli/Dockerfile
@@ -60,7 +60,6 @@ RUN set -ex; \
 	mkdir -p /var/www/html; \
 	chown -R www-data:www-data /var/www/html
 WORKDIR /var/www/html
-VOLUME /var/www/html
 
 # https://make.wordpress.org/cli/2018/05/31/gpg-signature-change/
 # pub   rsa2048 2018-05-31 [SC]
@@ -92,6 +91,8 @@ RUN set -ex; \
 	apk del .fetch-deps; \
 	\
 	wp --allow-root --version
+
+VOLUME /var/www/html
 
 COPY docker-entrypoint.sh /usr/local/bin/
 

--- a/php7.4/fpm-alpine/Dockerfile
+++ b/php7.4/fpm-alpine/Dockerfile
@@ -68,7 +68,6 @@ RUN { \
 		echo 'html_errors = Off'; \
 	} > /usr/local/etc/php/conf.d/error-logging.ini
 
-VOLUME /var/www/html
 
 ENV WORDPRESS_VERSION 5.4.1
 ENV WORDPRESS_SHA1 9800c231828eb5cd76ba0b8aa6c1a74dfca2daff
@@ -79,7 +78,17 @@ RUN set -ex; \
 # upstream tarballs include ./wordpress/ so this gives us /usr/src/wordpress
 	tar -xzf wordpress.tar.gz -C /usr/src/; \
 	rm wordpress.tar.gz; \
-	chown -R www-data:www-data /usr/src/wordpress
+	chown -R www-data:www-data /usr/src/wordpress; \
+# pre-create wp-content (and single-level children) for folks who want to bind-mount themes, etc so permissions are pre-created properly instead of root:root
+	mkdir wp-content; \
+	for dir in /usr/src/wordpress/wp-content/*/; do \
+		dir="$(basename "${dir%/}")"; \
+		mkdir "wp-content/$dir"; \
+	done; \
+	chown -R www-data:www-data wp-content; \
+	chmod -R 777 wp-content
+
+VOLUME /var/www/html
 
 COPY docker-entrypoint.sh /usr/local/bin/
 

--- a/php7.4/fpm-alpine/docker-entrypoint.sh
+++ b/php7.4/fpm-alpine/docker-entrypoint.sh
@@ -52,7 +52,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		fi
 
 		echo >&2 "WordPress not found in $PWD - copying now..."
-		if [ -n "$(ls -A)" ]; then
+		if [ -n "$(find -mindepth 1 -maxdepth 1 -not -name wp-content)" ]; then
 			echo >&2 "WARNING: $PWD is not empty! (copying anyhow)"
 		fi
 		sourceTarArgs=(

--- a/php7.4/fpm/Dockerfile
+++ b/php7.4/fpm/Dockerfile
@@ -73,7 +73,6 @@ RUN { \
 		echo 'html_errors = Off'; \
 	} > /usr/local/etc/php/conf.d/error-logging.ini
 
-VOLUME /var/www/html
 
 ENV WORDPRESS_VERSION 5.4.1
 ENV WORDPRESS_SHA1 9800c231828eb5cd76ba0b8aa6c1a74dfca2daff
@@ -84,7 +83,17 @@ RUN set -ex; \
 # upstream tarballs include ./wordpress/ so this gives us /usr/src/wordpress
 	tar -xzf wordpress.tar.gz -C /usr/src/; \
 	rm wordpress.tar.gz; \
-	chown -R www-data:www-data /usr/src/wordpress
+	chown -R www-data:www-data /usr/src/wordpress; \
+# pre-create wp-content (and single-level children) for folks who want to bind-mount themes, etc so permissions are pre-created properly instead of root:root
+	mkdir wp-content; \
+	for dir in /usr/src/wordpress/wp-content/*/; do \
+		dir="$(basename "${dir%/}")"; \
+		mkdir "wp-content/$dir"; \
+	done; \
+	chown -R www-data:www-data wp-content; \
+	chmod -R 777 wp-content
+
+VOLUME /var/www/html
 
 COPY docker-entrypoint.sh /usr/local/bin/
 

--- a/php7.4/fpm/docker-entrypoint.sh
+++ b/php7.4/fpm/docker-entrypoint.sh
@@ -52,7 +52,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		fi
 
 		echo >&2 "WordPress not found in $PWD - copying now..."
-		if [ -n "$(ls -A)" ]; then
+		if [ -n "$(find -mindepth 1 -maxdepth 1 -not -name wp-content)" ]; then
 			echo >&2 "WARNING: $PWD is not empty! (copying anyhow)"
 		fi
 		sourceTarArgs=(


### PR DESCRIPTION
Fixes #436
Closes #474

This is an alternative to #474 that doesn't revert the intent of #74, but still provides a fix for #436.