### PR TITLE
Update default PHP version to 7.4

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -3,7 +3,7 @@ set -eu
 
 # https://wordpress.org/about/requirements/
 # https://wordpress.org/support/update-php/#before-you-update-your-php-version
-defaultPhpVersion='php7.3'
+defaultPhpVersion='php7.4'
 defaultVariant='apache'
 
 self="$(basename "$BASH_SOURCE")"


### PR DESCRIPTION
This is per upstream's updated recommendation at https://wordpress.org/about/requirements/

Closes #509