### PR TITLE
Added sensible security defaults to apache images

### DIFF
--- a/apache-extras.template
+++ b/apache-extras.template
@@ -15,4 +15,12 @@ RUN set -eux; \
 	a2enconf remoteip; \
 # https://github.com/docker-library/wordpress/issues/383#issuecomment-507886512
 # (replace all instances of "%h" with "%a" in LogFormat)
-	find /etc/apache2 -type f -name '*.conf' -exec sed -ri 's/([[:space:]]*LogFormat[[:space:]]+"[^"]*)%h([^"]*")/\1%a\2/g' '{}' +
+	find /etc/apache2 -type f -name '*.conf' -exec sed -ri 's/([[:space:]]*LogFormat[[:space:]]+"[^"]*)%h([^"]*")/\1%a\2/g' '{}' +; \
+# apply sensible security defaults: 403 hidden files/dirs + common backup/source filetypes
+        { \
+                echo 'RedirectMatch 403 /\..*$'; \
+                echo '<FilesMatch "(\.(bak|back|backup|config|dist|fla|inc|ini|log|psd|sh|sql|swp)|~)$">'; \
+                echo 'Require all denied'; \
+                echo '</FilesMatch>'; \
+        } > /etc/apache2/conf-available/forbidden.conf; \
+        a2enconf forbidden

--- a/php7.2/apache/Dockerfile
+++ b/php7.2/apache/Dockerfile
@@ -90,7 +90,15 @@ RUN set -eux; \
 	a2enconf remoteip; \
 # https://github.com/docker-library/wordpress/issues/383#issuecomment-507886512
 # (replace all instances of "%h" with "%a" in LogFormat)
-	find /etc/apache2 -type f -name '*.conf' -exec sed -ri 's/([[:space:]]*LogFormat[[:space:]]+"[^"]*)%h([^"]*")/\1%a\2/g' '{}' +
+	find /etc/apache2 -type f -name '*.conf' -exec sed -ri 's/([[:space:]]*LogFormat[[:space:]]+"[^"]*)%h([^"]*")/\1%a\2/g' '{}' +; \
+# apply sensible security defaults: 403 hidden files/dirs + common backup/source filetypes
+        { \
+                echo 'RedirectMatch 403 /\..*$'; \
+                echo '<FilesMatch "(\.(bak|back|backup|config|dist|fla|inc|ini|log|psd|sh|sql|swp)|~)$">'; \
+                echo 'Require all denied'; \
+                echo '</FilesMatch>'; \
+        } > /etc/apache2/conf-available/forbidden.conf; \
+        a2enconf forbidden
 
 
 ENV WORDPRESS_VERSION 5.5

--- a/php7.3/apache/Dockerfile
+++ b/php7.3/apache/Dockerfile
@@ -91,7 +91,15 @@ RUN set -eux; \
 	a2enconf remoteip; \
 # https://github.com/docker-library/wordpress/issues/383#issuecomment-507886512
 # (replace all instances of "%h" with "%a" in LogFormat)
-	find /etc/apache2 -type f -name '*.conf' -exec sed -ri 's/([[:space:]]*LogFormat[[:space:]]+"[^"]*)%h([^"]*")/\1%a\2/g' '{}' +
+	find /etc/apache2 -type f -name '*.conf' -exec sed -ri 's/([[:space:]]*LogFormat[[:space:]]+"[^"]*)%h([^"]*")/\1%a\2/g' '{}' +; \
+# apply some sensible security defaults: 403 hidden files/dirs + common backup/source filetypes
+        { \
+                echo 'RedirectMatch 403 /\..*$'; \
+                echo '<FilesMatch "(\.(bak|back|backup|config|dist|fla|inc|ini|log|psd|sh|sql|swp)|~)$">'; \
+                echo 'Require all denied'; \
+                echo '</FilesMatch>'; \
+        } > /etc/apache2/conf-available/forbidden.conf; \
+        a2enconf forbidden
 
 
 ENV WORDPRESS_VERSION 5.5

--- a/php7.4/apache/Dockerfile
+++ b/php7.4/apache/Dockerfile
@@ -91,7 +91,15 @@ RUN set -eux; \
 	a2enconf remoteip; \
 # https://github.com/docker-library/wordpress/issues/383#issuecomment-507886512
 # (replace all instances of "%h" with "%a" in LogFormat)
-	find /etc/apache2 -type f -name '*.conf' -exec sed -ri 's/([[:space:]]*LogFormat[[:space:]]+"[^"]*)%h([^"]*")/\1%a\2/g' '{}' +
+	find /etc/apache2 -type f -name '*.conf' -exec sed -ri 's/([[:space:]]*LogFormat[[:space:]]+"[^"]*)%h([^"]*")/\1%a\2/g' '{}' +; \
+# apply sensible security defaults: 403 hidden files/dirs + common backup/source filetypes
+	{ \
+		echo 'RedirectMatch 403 /\..*$'; \
+		echo '<FilesMatch "(\.(bak|back|backup|config|dist|fla|inc|ini|log|psd|sh|sql|swp)|~)$">'; \
+		echo 'Require all denied'; \
+		echo '</FilesMatch>'; \
+	} > /etc/apache2/conf-available/forbidden.conf; \
+	a2enconf forbidden
 
 
 ENV WORDPRESS_VERSION 5.5


### PR DESCRIPTION
Add 403 response for hidden files/dirs and common backup/source file types.

Primary motivation is to avoid `.git` directories being accessible. Obviously I can extend the wordpress image to include my requirements here, or even just add to `.htaccess` - but felt like this would be a good addition to the base image.

Persistent file storage tends to "build up badness" over time... and it'd be a highly unusual case to want these types of files/dirs served even on a development environment... so worth adding to help protect people from themselves :)