### PR TITLE
Add mcrypt PHP extension

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -64,6 +64,7 @@ RUN set -ex; \
 		libjpeg-turbo-dev \
 		libpng-dev \
 		libzip-dev \
+		libmcrypt-dev \
 	; \
 {{ ) else ( -}}
 	savedAptMark="$(apt-mark showmanual)"; \
@@ -77,6 +78,7 @@ RUN set -ex; \
 {{ ) else "" end -}}
 		libpng-dev \
 		libzip-dev \
+		libmcrypt-dev \
 	; \
 {{ ) end -}}
 	\
@@ -101,6 +103,8 @@ RUN set -ex; \
 	pecl install imagick-3.4.4; \
 	docker-php-ext-enable imagick; \
 {{ ) else "" end -}}
+	pecl install mcrypt-1.0.4; \
+	docker-php-ext-enable mcrypt; \
 	\
 {{ if is_alpine then ( -}}
 	runDeps="$( \


### PR DESCRIPTION
According to https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions `mcrypt` in only an optional PHP extension ("Generates random bytes when libsodium and /dev/urandom aren’t available"), but it is also the only extension in the documentation-provided list to _not_ be included in this Docker image.
This PR adds `mcrypt` to the list of installed PHP extensions.