### PR TITLE
Re-add ability to create db if it did not exist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,5 +44,7 @@ jobs:
         run: ${{ matrix.runs.history }}
       - name: Test ${{ matrix.name }}
         run: ${{ matrix.runs.test }}
+        env:
+          SKIP_DB_CREATION: true
       - name: '"docker images"'
         run: ${{ matrix.runs.images }}

--- a/beta/php7.3/apache/docker-entrypoint.sh
+++ b/beta/php7.3/apache/docker-entrypoint.sh
@@ -87,12 +87,12 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
-
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
+		export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+		export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+		export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-}
+		export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"wordpress"}
+
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/beta/php7.3/apache/docker-entrypoint.sh
+++ b/beta/php7.3/apache/docker-entrypoint.sh
@@ -87,7 +87,13 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	if ! TERM=dumb php -- <<'EOPHP'
+	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+
+	if [ -z ${SKIP_DB_CREATION+x} ] then
+		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 $stderr = fopen('php://stderr', 'w');
@@ -123,11 +129,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 }
 $mysql->close();
 EOPHP
-	then
-		echo >&2
-		echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
-		echo >&2 '  continuing anyways (which might have unexpected results)'
-		echo >&2
+		then
+			echo >&2
+			echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
+			echo >&2 '  continuing anyways (which might have unexpected results)'
+			echo >&2
+		fi
 	fi
 fi
 

--- a/beta/php7.3/apache/docker-entrypoint.sh
+++ b/beta/php7.3/apache/docker-entrypoint.sh
@@ -92,7 +92,7 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
 	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
-	if [ -z ${SKIP_DB_CREATION+x} ] then
+	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/beta/php7.3/apache/docker-entrypoint.sh
+++ b/beta/php7.3/apache/docker-entrypoint.sh
@@ -87,10 +87,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
@@ -101,15 +101,15 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = getenv('WORDPRESS_DB_HOST') ? explode(':', getenv('WORDPRESS_DB_HOST'), 2) : 'mysql';
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
-$user = getenv('WORDPRESS_DB_USER') ?: 'root';
-$pass = getenv('WORDPRESS_DB_PASSWORD') ?: '';
-$dbName = getenv('WORDPRESS_DB_NAME') ?: 'wordpress';
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 $maxTries = 10;
 do {
 	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);

--- a/beta/php7.3/fpm-alpine/docker-entrypoint.sh
+++ b/beta/php7.3/fpm-alpine/docker-entrypoint.sh
@@ -87,12 +87,12 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
-
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
+		export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+		export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+		export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-}
+		export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"wordpress"}
+
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/beta/php7.3/fpm-alpine/docker-entrypoint.sh
+++ b/beta/php7.3/fpm-alpine/docker-entrypoint.sh
@@ -87,7 +87,13 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	if ! TERM=dumb php -- <<'EOPHP'
+	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+
+	if [ -z ${SKIP_DB_CREATION+x} ] then
+		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 $stderr = fopen('php://stderr', 'w');
@@ -123,11 +129,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 }
 $mysql->close();
 EOPHP
-	then
-		echo >&2
-		echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
-		echo >&2 '  continuing anyways (which might have unexpected results)'
-		echo >&2
+		then
+			echo >&2
+			echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
+			echo >&2 '  continuing anyways (which might have unexpected results)'
+			echo >&2
+		fi
 	fi
 fi
 

--- a/beta/php7.3/fpm-alpine/docker-entrypoint.sh
+++ b/beta/php7.3/fpm-alpine/docker-entrypoint.sh
@@ -92,7 +92,7 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
 	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
-	if [ -z ${SKIP_DB_CREATION+x} ] then
+	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/beta/php7.3/fpm-alpine/docker-entrypoint.sh
+++ b/beta/php7.3/fpm-alpine/docker-entrypoint.sh
@@ -87,10 +87,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
@@ -101,15 +101,15 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = getenv('WORDPRESS_DB_HOST') ? explode(':', getenv('WORDPRESS_DB_HOST'), 2) : 'mysql';
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
-$user = getenv('WORDPRESS_DB_USER') ?: 'root';
-$pass = getenv('WORDPRESS_DB_PASSWORD') ?: '';
-$dbName = getenv('WORDPRESS_DB_NAME') ?: 'wordpress';
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 $maxTries = 10;
 do {
 	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);

--- a/beta/php7.3/fpm/docker-entrypoint.sh
+++ b/beta/php7.3/fpm/docker-entrypoint.sh
@@ -87,12 +87,12 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
-
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
+		export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+		export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+		export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-}
+		export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"wordpress"}
+
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/beta/php7.3/fpm/docker-entrypoint.sh
+++ b/beta/php7.3/fpm/docker-entrypoint.sh
@@ -87,7 +87,13 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	if ! TERM=dumb php -- <<'EOPHP'
+	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+
+	if [ -z ${SKIP_DB_CREATION+x} ] then
+		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 $stderr = fopen('php://stderr', 'w');
@@ -123,11 +129,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 }
 $mysql->close();
 EOPHP
-	then
-		echo >&2
-		echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
-		echo >&2 '  continuing anyways (which might have unexpected results)'
-		echo >&2
+		then
+			echo >&2
+			echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
+			echo >&2 '  continuing anyways (which might have unexpected results)'
+			echo >&2
+		fi
 	fi
 fi
 

--- a/beta/php7.3/fpm/docker-entrypoint.sh
+++ b/beta/php7.3/fpm/docker-entrypoint.sh
@@ -92,7 +92,7 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
 	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
-	if [ -z ${SKIP_DB_CREATION+x} ] then
+	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/beta/php7.3/fpm/docker-entrypoint.sh
+++ b/beta/php7.3/fpm/docker-entrypoint.sh
@@ -87,10 +87,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
@@ -101,15 +101,15 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = getenv('WORDPRESS_DB_HOST') ? explode(':', getenv('WORDPRESS_DB_HOST'), 2) : 'mysql';
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
-$user = getenv('WORDPRESS_DB_USER') ?: 'root';
-$pass = getenv('WORDPRESS_DB_PASSWORD') ?: '';
-$dbName = getenv('WORDPRESS_DB_NAME') ?: 'wordpress';
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 $maxTries = 10;
 do {
 	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);

--- a/beta/php7.4/apache/docker-entrypoint.sh
+++ b/beta/php7.4/apache/docker-entrypoint.sh
@@ -87,12 +87,12 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
-
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
+		export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+		export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+		export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-}
+		export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"wordpress"}
+
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/beta/php7.4/apache/docker-entrypoint.sh
+++ b/beta/php7.4/apache/docker-entrypoint.sh
@@ -87,7 +87,13 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	if ! TERM=dumb php -- <<'EOPHP'
+	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+
+	if [ -z ${SKIP_DB_CREATION+x} ] then
+		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 $stderr = fopen('php://stderr', 'w');
@@ -123,11 +129,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 }
 $mysql->close();
 EOPHP
-	then
-		echo >&2
-		echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
-		echo >&2 '  continuing anyways (which might have unexpected results)'
-		echo >&2
+		then
+			echo >&2
+			echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
+			echo >&2 '  continuing anyways (which might have unexpected results)'
+			echo >&2
+		fi
 	fi
 fi
 

--- a/beta/php7.4/apache/docker-entrypoint.sh
+++ b/beta/php7.4/apache/docker-entrypoint.sh
@@ -92,7 +92,7 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
 	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
-	if [ -z ${SKIP_DB_CREATION+x} ] then
+	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/beta/php7.4/apache/docker-entrypoint.sh
+++ b/beta/php7.4/apache/docker-entrypoint.sh
@@ -87,10 +87,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
@@ -101,15 +101,15 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = getenv('WORDPRESS_DB_HOST') ? explode(':', getenv('WORDPRESS_DB_HOST'), 2) : 'mysql';
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
-$user = getenv('WORDPRESS_DB_USER') ?: 'root';
-$pass = getenv('WORDPRESS_DB_PASSWORD') ?: '';
-$dbName = getenv('WORDPRESS_DB_NAME') ?: 'wordpress';
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 $maxTries = 10;
 do {
 	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);

--- a/beta/php7.4/fpm-alpine/docker-entrypoint.sh
+++ b/beta/php7.4/fpm-alpine/docker-entrypoint.sh
@@ -87,12 +87,12 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
-
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
+		export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+		export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+		export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-}
+		export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"wordpress"}
+
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/beta/php7.4/fpm-alpine/docker-entrypoint.sh
+++ b/beta/php7.4/fpm-alpine/docker-entrypoint.sh
@@ -87,7 +87,13 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	if ! TERM=dumb php -- <<'EOPHP'
+	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+
+	if [ -z ${SKIP_DB_CREATION+x} ] then
+		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 $stderr = fopen('php://stderr', 'w');
@@ -123,11 +129,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 }
 $mysql->close();
 EOPHP
-	then
-		echo >&2
-		echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
-		echo >&2 '  continuing anyways (which might have unexpected results)'
-		echo >&2
+		then
+			echo >&2
+			echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
+			echo >&2 '  continuing anyways (which might have unexpected results)'
+			echo >&2
+		fi
 	fi
 fi
 

--- a/beta/php7.4/fpm-alpine/docker-entrypoint.sh
+++ b/beta/php7.4/fpm-alpine/docker-entrypoint.sh
@@ -92,7 +92,7 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
 	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
-	if [ -z ${SKIP_DB_CREATION+x} ] then
+	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/beta/php7.4/fpm-alpine/docker-entrypoint.sh
+++ b/beta/php7.4/fpm-alpine/docker-entrypoint.sh
@@ -87,10 +87,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
@@ -101,15 +101,15 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = getenv('WORDPRESS_DB_HOST') ? explode(':', getenv('WORDPRESS_DB_HOST'), 2) : 'mysql';
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
-$user = getenv('WORDPRESS_DB_USER') ?: 'root';
-$pass = getenv('WORDPRESS_DB_PASSWORD') ?: '';
-$dbName = getenv('WORDPRESS_DB_NAME') ?: 'wordpress';
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 $maxTries = 10;
 do {
 	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);

--- a/beta/php7.4/fpm/docker-entrypoint.sh
+++ b/beta/php7.4/fpm/docker-entrypoint.sh
@@ -87,12 +87,12 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
-
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
+		export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+		export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+		export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-}
+		export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"wordpress"}
+
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/beta/php7.4/fpm/docker-entrypoint.sh
+++ b/beta/php7.4/fpm/docker-entrypoint.sh
@@ -87,7 +87,13 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	if ! TERM=dumb php -- <<'EOPHP'
+	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+
+	if [ -z ${SKIP_DB_CREATION+x} ] then
+		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 $stderr = fopen('php://stderr', 'w');
@@ -123,11 +129,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 }
 $mysql->close();
 EOPHP
-	then
-		echo >&2
-		echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
-		echo >&2 '  continuing anyways (which might have unexpected results)'
-		echo >&2
+		then
+			echo >&2
+			echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
+			echo >&2 '  continuing anyways (which might have unexpected results)'
+			echo >&2
+		fi
 	fi
 fi
 

--- a/beta/php7.4/fpm/docker-entrypoint.sh
+++ b/beta/php7.4/fpm/docker-entrypoint.sh
@@ -92,7 +92,7 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
 	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
-	if [ -z ${SKIP_DB_CREATION+x} ] then
+	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/beta/php7.4/fpm/docker-entrypoint.sh
+++ b/beta/php7.4/fpm/docker-entrypoint.sh
@@ -87,10 +87,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
@@ -101,15 +101,15 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = getenv('WORDPRESS_DB_HOST') ? explode(':', getenv('WORDPRESS_DB_HOST'), 2) : 'mysql';
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
-$user = getenv('WORDPRESS_DB_USER') ?: 'root';
-$pass = getenv('WORDPRESS_DB_PASSWORD') ?: '';
-$dbName = getenv('WORDPRESS_DB_NAME') ?: 'wordpress';
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 $maxTries = 10;
 do {
 	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);

--- a/beta/php8.0/apache/docker-entrypoint.sh
+++ b/beta/php8.0/apache/docker-entrypoint.sh
@@ -87,12 +87,12 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
-
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
+		export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+		export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+		export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-}
+		export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"wordpress"}
+
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/beta/php8.0/apache/docker-entrypoint.sh
+++ b/beta/php8.0/apache/docker-entrypoint.sh
@@ -87,7 +87,13 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	if ! TERM=dumb php -- <<'EOPHP'
+	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+
+	if [ -z ${SKIP_DB_CREATION+x} ] then
+		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 $stderr = fopen('php://stderr', 'w');
@@ -123,11 +129,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 }
 $mysql->close();
 EOPHP
-	then
-		echo >&2
-		echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
-		echo >&2 '  continuing anyways (which might have unexpected results)'
-		echo >&2
+		then
+			echo >&2
+			echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
+			echo >&2 '  continuing anyways (which might have unexpected results)'
+			echo >&2
+		fi
 	fi
 fi
 

--- a/beta/php8.0/apache/docker-entrypoint.sh
+++ b/beta/php8.0/apache/docker-entrypoint.sh
@@ -92,7 +92,7 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
 	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
-	if [ -z ${SKIP_DB_CREATION+x} ] then
+	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/beta/php8.0/apache/docker-entrypoint.sh
+++ b/beta/php8.0/apache/docker-entrypoint.sh
@@ -87,10 +87,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
@@ -101,15 +101,15 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = getenv('WORDPRESS_DB_HOST') ? explode(':', getenv('WORDPRESS_DB_HOST'), 2) : 'mysql';
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
-$user = getenv('WORDPRESS_DB_USER') ?: 'root';
-$pass = getenv('WORDPRESS_DB_PASSWORD') ?: '';
-$dbName = getenv('WORDPRESS_DB_NAME') ?: 'wordpress';
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 $maxTries = 10;
 do {
 	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);

--- a/beta/php8.0/fpm-alpine/docker-entrypoint.sh
+++ b/beta/php8.0/fpm-alpine/docker-entrypoint.sh
@@ -87,12 +87,12 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
-
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
+		export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+		export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+		export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-}
+		export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"wordpress"}
+
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/beta/php8.0/fpm-alpine/docker-entrypoint.sh
+++ b/beta/php8.0/fpm-alpine/docker-entrypoint.sh
@@ -87,7 +87,13 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	if ! TERM=dumb php -- <<'EOPHP'
+	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+
+	if [ -z ${SKIP_DB_CREATION+x} ] then
+		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 $stderr = fopen('php://stderr', 'w');
@@ -123,11 +129,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 }
 $mysql->close();
 EOPHP
-	then
-		echo >&2
-		echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
-		echo >&2 '  continuing anyways (which might have unexpected results)'
-		echo >&2
+		then
+			echo >&2
+			echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
+			echo >&2 '  continuing anyways (which might have unexpected results)'
+			echo >&2
+		fi
 	fi
 fi
 

--- a/beta/php8.0/fpm-alpine/docker-entrypoint.sh
+++ b/beta/php8.0/fpm-alpine/docker-entrypoint.sh
@@ -92,7 +92,7 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
 	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
-	if [ -z ${SKIP_DB_CREATION+x} ] then
+	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/beta/php8.0/fpm-alpine/docker-entrypoint.sh
+++ b/beta/php8.0/fpm-alpine/docker-entrypoint.sh
@@ -87,10 +87,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
@@ -101,15 +101,15 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = getenv('WORDPRESS_DB_HOST') ? explode(':', getenv('WORDPRESS_DB_HOST'), 2) : 'mysql';
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
-$user = getenv('WORDPRESS_DB_USER') ?: 'root';
-$pass = getenv('WORDPRESS_DB_PASSWORD') ?: '';
-$dbName = getenv('WORDPRESS_DB_NAME') ?: 'wordpress';
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 $maxTries = 10;
 do {
 	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);

--- a/beta/php8.0/fpm/docker-entrypoint.sh
+++ b/beta/php8.0/fpm/docker-entrypoint.sh
@@ -87,12 +87,12 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
-
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
+		export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+		export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+		export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-}
+		export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"wordpress"}
+
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/beta/php8.0/fpm/docker-entrypoint.sh
+++ b/beta/php8.0/fpm/docker-entrypoint.sh
@@ -87,7 +87,13 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	if ! TERM=dumb php -- <<'EOPHP'
+	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+
+	if [ -z ${SKIP_DB_CREATION+x} ] then
+		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 $stderr = fopen('php://stderr', 'w');
@@ -123,11 +129,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 }
 $mysql->close();
 EOPHP
-	then
-		echo >&2
-		echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
-		echo >&2 '  continuing anyways (which might have unexpected results)'
-		echo >&2
+		then
+			echo >&2
+			echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
+			echo >&2 '  continuing anyways (which might have unexpected results)'
+			echo >&2
+		fi
 	fi
 fi
 

--- a/beta/php8.0/fpm/docker-entrypoint.sh
+++ b/beta/php8.0/fpm/docker-entrypoint.sh
@@ -92,7 +92,7 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
 	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
-	if [ -z ${SKIP_DB_CREATION+x} ] then
+	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/beta/php8.0/fpm/docker-entrypoint.sh
+++ b/beta/php8.0/fpm/docker-entrypoint.sh
@@ -87,10 +87,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
@@ -101,15 +101,15 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = getenv('WORDPRESS_DB_HOST') ? explode(':', getenv('WORDPRESS_DB_HOST'), 2) : 'mysql';
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
-$user = getenv('WORDPRESS_DB_USER') ?: 'root';
-$pass = getenv('WORDPRESS_DB_PASSWORD') ?: '';
-$dbName = getenv('WORDPRESS_DB_NAME') ?: 'wordpress';
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 $maxTries = 10;
 do {
 	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -87,12 +87,12 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
-
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
+		export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+		export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+		export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-}
+		export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"wordpress"}
+
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -87,7 +87,13 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	if ! TERM=dumb php -- <<'EOPHP'
+	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+
+	if [ -z ${SKIP_DB_CREATION+x} ] then
+		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 $stderr = fopen('php://stderr', 'w');
@@ -123,11 +129,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 }
 $mysql->close();
 EOPHP
-	then
-		echo >&2
-		echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
-		echo >&2 '  continuing anyways (which might have unexpected results)'
-		echo >&2
+		then
+			echo >&2
+			echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
+			echo >&2 '  continuing anyways (which might have unexpected results)'
+			echo >&2
+		fi
 	fi
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -92,7 +92,7 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
 	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
-	if [ -z ${SKIP_DB_CREATION+x} ] then
+	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -87,10 +87,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
@@ -101,15 +101,15 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = getenv('WORDPRESS_DB_HOST') ? explode(':', getenv('WORDPRESS_DB_HOST'), 2) : 'mysql';
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
-$user = getenv('WORDPRESS_DB_USER') ?: 'root';
-$pass = getenv('WORDPRESS_DB_PASSWORD') ?: '';
-$dbName = getenv('WORDPRESS_DB_NAME') ?: 'wordpress';
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 $maxTries = 10;
 do {
 	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);

--- a/latest/php7.3/apache/docker-entrypoint.sh
+++ b/latest/php7.3/apache/docker-entrypoint.sh
@@ -87,12 +87,12 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
-
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
+		export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+		export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+		export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-}
+		export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"wordpress"}
+
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/latest/php7.3/apache/docker-entrypoint.sh
+++ b/latest/php7.3/apache/docker-entrypoint.sh
@@ -87,7 +87,13 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	if ! TERM=dumb php -- <<'EOPHP'
+	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+
+	if [ -z ${SKIP_DB_CREATION+x} ] then
+		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 $stderr = fopen('php://stderr', 'w');
@@ -123,11 +129,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 }
 $mysql->close();
 EOPHP
-	then
-		echo >&2
-		echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
-		echo >&2 '  continuing anyways (which might have unexpected results)'
-		echo >&2
+		then
+			echo >&2
+			echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
+			echo >&2 '  continuing anyways (which might have unexpected results)'
+			echo >&2
+		fi
 	fi
 fi
 

--- a/latest/php7.3/apache/docker-entrypoint.sh
+++ b/latest/php7.3/apache/docker-entrypoint.sh
@@ -92,7 +92,7 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
 	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
-	if [ -z ${SKIP_DB_CREATION+x} ] then
+	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/latest/php7.3/apache/docker-entrypoint.sh
+++ b/latest/php7.3/apache/docker-entrypoint.sh
@@ -87,10 +87,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
@@ -101,15 +101,15 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = getenv('WORDPRESS_DB_HOST') ? explode(':', getenv('WORDPRESS_DB_HOST'), 2) : 'mysql';
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
-$user = getenv('WORDPRESS_DB_USER') ?: 'root';
-$pass = getenv('WORDPRESS_DB_PASSWORD') ?: '';
-$dbName = getenv('WORDPRESS_DB_NAME') ?: 'wordpress';
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 $maxTries = 10;
 do {
 	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);

--- a/latest/php7.3/fpm-alpine/docker-entrypoint.sh
+++ b/latest/php7.3/fpm-alpine/docker-entrypoint.sh
@@ -87,12 +87,12 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
-
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
+		export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+		export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+		export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-}
+		export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"wordpress"}
+
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/latest/php7.3/fpm-alpine/docker-entrypoint.sh
+++ b/latest/php7.3/fpm-alpine/docker-entrypoint.sh
@@ -87,7 +87,13 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	if ! TERM=dumb php -- <<'EOPHP'
+	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+
+	if [ -z ${SKIP_DB_CREATION+x} ] then
+		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 $stderr = fopen('php://stderr', 'w');
@@ -123,11 +129,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 }
 $mysql->close();
 EOPHP
-	then
-		echo >&2
-		echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
-		echo >&2 '  continuing anyways (which might have unexpected results)'
-		echo >&2
+		then
+			echo >&2
+			echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
+			echo >&2 '  continuing anyways (which might have unexpected results)'
+			echo >&2
+		fi
 	fi
 fi
 

--- a/latest/php7.3/fpm-alpine/docker-entrypoint.sh
+++ b/latest/php7.3/fpm-alpine/docker-entrypoint.sh
@@ -92,7 +92,7 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
 	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
-	if [ -z ${SKIP_DB_CREATION+x} ] then
+	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/latest/php7.3/fpm-alpine/docker-entrypoint.sh
+++ b/latest/php7.3/fpm-alpine/docker-entrypoint.sh
@@ -87,10 +87,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
@@ -101,15 +101,15 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = getenv('WORDPRESS_DB_HOST') ? explode(':', getenv('WORDPRESS_DB_HOST'), 2) : 'mysql';
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
-$user = getenv('WORDPRESS_DB_USER') ?: 'root';
-$pass = getenv('WORDPRESS_DB_PASSWORD') ?: '';
-$dbName = getenv('WORDPRESS_DB_NAME') ?: 'wordpress';
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 $maxTries = 10;
 do {
 	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);

--- a/latest/php7.3/fpm/docker-entrypoint.sh
+++ b/latest/php7.3/fpm/docker-entrypoint.sh
@@ -87,12 +87,12 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
-
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
+		export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+		export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+		export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-}
+		export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"wordpress"}
+
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/latest/php7.3/fpm/docker-entrypoint.sh
+++ b/latest/php7.3/fpm/docker-entrypoint.sh
@@ -87,7 +87,13 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	if ! TERM=dumb php -- <<'EOPHP'
+	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+
+	if [ -z ${SKIP_DB_CREATION+x} ] then
+		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 $stderr = fopen('php://stderr', 'w');
@@ -123,11 +129,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 }
 $mysql->close();
 EOPHP
-	then
-		echo >&2
-		echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
-		echo >&2 '  continuing anyways (which might have unexpected results)'
-		echo >&2
+		then
+			echo >&2
+			echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
+			echo >&2 '  continuing anyways (which might have unexpected results)'
+			echo >&2
+		fi
 	fi
 fi
 

--- a/latest/php7.3/fpm/docker-entrypoint.sh
+++ b/latest/php7.3/fpm/docker-entrypoint.sh
@@ -92,7 +92,7 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
 	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
-	if [ -z ${SKIP_DB_CREATION+x} ] then
+	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/latest/php7.3/fpm/docker-entrypoint.sh
+++ b/latest/php7.3/fpm/docker-entrypoint.sh
@@ -87,10 +87,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
@@ -101,15 +101,15 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = getenv('WORDPRESS_DB_HOST') ? explode(':', getenv('WORDPRESS_DB_HOST'), 2) : 'mysql';
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
-$user = getenv('WORDPRESS_DB_USER') ?: 'root';
-$pass = getenv('WORDPRESS_DB_PASSWORD') ?: '';
-$dbName = getenv('WORDPRESS_DB_NAME') ?: 'wordpress';
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 $maxTries = 10;
 do {
 	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);

--- a/latest/php7.4/apache/docker-entrypoint.sh
+++ b/latest/php7.4/apache/docker-entrypoint.sh
@@ -87,12 +87,12 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
-
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
+		export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+		export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+		export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-}
+		export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"wordpress"}
+
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/latest/php7.4/apache/docker-entrypoint.sh
+++ b/latest/php7.4/apache/docker-entrypoint.sh
@@ -87,7 +87,13 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	if ! TERM=dumb php -- <<'EOPHP'
+	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+
+	if [ -z ${SKIP_DB_CREATION+x} ] then
+		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 $stderr = fopen('php://stderr', 'w');
@@ -123,11 +129,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 }
 $mysql->close();
 EOPHP
-	then
-		echo >&2
-		echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
-		echo >&2 '  continuing anyways (which might have unexpected results)'
-		echo >&2
+		then
+			echo >&2
+			echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
+			echo >&2 '  continuing anyways (which might have unexpected results)'
+			echo >&2
+		fi
 	fi
 fi
 

--- a/latest/php7.4/apache/docker-entrypoint.sh
+++ b/latest/php7.4/apache/docker-entrypoint.sh
@@ -92,7 +92,7 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
 	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
-	if [ -z ${SKIP_DB_CREATION+x} ] then
+	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/latest/php7.4/apache/docker-entrypoint.sh
+++ b/latest/php7.4/apache/docker-entrypoint.sh
@@ -87,10 +87,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
@@ -101,15 +101,15 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = getenv('WORDPRESS_DB_HOST') ? explode(':', getenv('WORDPRESS_DB_HOST'), 2) : 'mysql';
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
-$user = getenv('WORDPRESS_DB_USER') ?: 'root';
-$pass = getenv('WORDPRESS_DB_PASSWORD') ?: '';
-$dbName = getenv('WORDPRESS_DB_NAME') ?: 'wordpress';
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 $maxTries = 10;
 do {
 	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);

--- a/latest/php7.4/fpm-alpine/docker-entrypoint.sh
+++ b/latest/php7.4/fpm-alpine/docker-entrypoint.sh
@@ -87,12 +87,12 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
-
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
+		export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+		export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+		export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-}
+		export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"wordpress"}
+
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/latest/php7.4/fpm-alpine/docker-entrypoint.sh
+++ b/latest/php7.4/fpm-alpine/docker-entrypoint.sh
@@ -87,7 +87,13 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	if ! TERM=dumb php -- <<'EOPHP'
+	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+
+	if [ -z ${SKIP_DB_CREATION+x} ] then
+		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 $stderr = fopen('php://stderr', 'w');
@@ -123,11 +129,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 }
 $mysql->close();
 EOPHP
-	then
-		echo >&2
-		echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
-		echo >&2 '  continuing anyways (which might have unexpected results)'
-		echo >&2
+		then
+			echo >&2
+			echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
+			echo >&2 '  continuing anyways (which might have unexpected results)'
+			echo >&2
+		fi
 	fi
 fi
 

--- a/latest/php7.4/fpm-alpine/docker-entrypoint.sh
+++ b/latest/php7.4/fpm-alpine/docker-entrypoint.sh
@@ -92,7 +92,7 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
 	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
-	if [ -z ${SKIP_DB_CREATION+x} ] then
+	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/latest/php7.4/fpm-alpine/docker-entrypoint.sh
+++ b/latest/php7.4/fpm-alpine/docker-entrypoint.sh
@@ -87,10 +87,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
@@ -101,15 +101,15 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = getenv('WORDPRESS_DB_HOST') ? explode(':', getenv('WORDPRESS_DB_HOST'), 2) : 'mysql';
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
-$user = getenv('WORDPRESS_DB_USER') ?: 'root';
-$pass = getenv('WORDPRESS_DB_PASSWORD') ?: '';
-$dbName = getenv('WORDPRESS_DB_NAME') ?: 'wordpress';
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 $maxTries = 10;
 do {
 	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);

--- a/latest/php7.4/fpm/docker-entrypoint.sh
+++ b/latest/php7.4/fpm/docker-entrypoint.sh
@@ -87,12 +87,12 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
-
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
+		export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+		export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+		export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-}
+		export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"wordpress"}
+
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/latest/php7.4/fpm/docker-entrypoint.sh
+++ b/latest/php7.4/fpm/docker-entrypoint.sh
@@ -87,7 +87,13 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	if ! TERM=dumb php -- <<'EOPHP'
+	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+
+	if [ -z ${SKIP_DB_CREATION+x} ] then
+		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 $stderr = fopen('php://stderr', 'w');
@@ -123,11 +129,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 }
 $mysql->close();
 EOPHP
-	then
-		echo >&2
-		echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
-		echo >&2 '  continuing anyways (which might have unexpected results)'
-		echo >&2
+		then
+			echo >&2
+			echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
+			echo >&2 '  continuing anyways (which might have unexpected results)'
+			echo >&2
+		fi
 	fi
 fi
 

--- a/latest/php7.4/fpm/docker-entrypoint.sh
+++ b/latest/php7.4/fpm/docker-entrypoint.sh
@@ -92,7 +92,7 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
 	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
-	if [ -z ${SKIP_DB_CREATION+x} ] then
+	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/latest/php7.4/fpm/docker-entrypoint.sh
+++ b/latest/php7.4/fpm/docker-entrypoint.sh
@@ -87,10 +87,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
@@ -101,15 +101,15 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = getenv('WORDPRESS_DB_HOST') ? explode(':', getenv('WORDPRESS_DB_HOST'), 2) : 'mysql';
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
-$user = getenv('WORDPRESS_DB_USER') ?: 'root';
-$pass = getenv('WORDPRESS_DB_PASSWORD') ?: '';
-$dbName = getenv('WORDPRESS_DB_NAME') ?: 'wordpress';
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 $maxTries = 10;
 do {
 	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);

--- a/latest/php8.0/apache/docker-entrypoint.sh
+++ b/latest/php8.0/apache/docker-entrypoint.sh
@@ -87,12 +87,12 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
-
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
+		export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+		export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+		export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-}
+		export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"wordpress"}
+
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/latest/php8.0/apache/docker-entrypoint.sh
+++ b/latest/php8.0/apache/docker-entrypoint.sh
@@ -87,7 +87,13 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	if ! TERM=dumb php -- <<'EOPHP'
+	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+
+	if [ -z ${SKIP_DB_CREATION+x} ] then
+		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 $stderr = fopen('php://stderr', 'w');
@@ -123,11 +129,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 }
 $mysql->close();
 EOPHP
-	then
-		echo >&2
-		echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
-		echo >&2 '  continuing anyways (which might have unexpected results)'
-		echo >&2
+		then
+			echo >&2
+			echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
+			echo >&2 '  continuing anyways (which might have unexpected results)'
+			echo >&2
+		fi
 	fi
 fi
 

--- a/latest/php8.0/apache/docker-entrypoint.sh
+++ b/latest/php8.0/apache/docker-entrypoint.sh
@@ -92,7 +92,7 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
 	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
-	if [ -z ${SKIP_DB_CREATION+x} ] then
+	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/latest/php8.0/apache/docker-entrypoint.sh
+++ b/latest/php8.0/apache/docker-entrypoint.sh
@@ -87,10 +87,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
@@ -101,15 +101,15 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = getenv('WORDPRESS_DB_HOST') ? explode(':', getenv('WORDPRESS_DB_HOST'), 2) : 'mysql';
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
-$user = getenv('WORDPRESS_DB_USER') ?: 'root';
-$pass = getenv('WORDPRESS_DB_PASSWORD') ?: '';
-$dbName = getenv('WORDPRESS_DB_NAME') ?: 'wordpress';
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 $maxTries = 10;
 do {
 	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);

--- a/latest/php8.0/fpm-alpine/docker-entrypoint.sh
+++ b/latest/php8.0/fpm-alpine/docker-entrypoint.sh
@@ -87,12 +87,12 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
-
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
+		export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+		export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+		export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-}
+		export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"wordpress"}
+
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/latest/php8.0/fpm-alpine/docker-entrypoint.sh
+++ b/latest/php8.0/fpm-alpine/docker-entrypoint.sh
@@ -87,7 +87,13 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	if ! TERM=dumb php -- <<'EOPHP'
+	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+
+	if [ -z ${SKIP_DB_CREATION+x} ] then
+		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 $stderr = fopen('php://stderr', 'w');
@@ -123,11 +129,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 }
 $mysql->close();
 EOPHP
-	then
-		echo >&2
-		echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
-		echo >&2 '  continuing anyways (which might have unexpected results)'
-		echo >&2
+		then
+			echo >&2
+			echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
+			echo >&2 '  continuing anyways (which might have unexpected results)'
+			echo >&2
+		fi
 	fi
 fi
 

--- a/latest/php8.0/fpm-alpine/docker-entrypoint.sh
+++ b/latest/php8.0/fpm-alpine/docker-entrypoint.sh
@@ -92,7 +92,7 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
 	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
-	if [ -z ${SKIP_DB_CREATION+x} ] then
+	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/latest/php8.0/fpm-alpine/docker-entrypoint.sh
+++ b/latest/php8.0/fpm-alpine/docker-entrypoint.sh
@@ -87,10 +87,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
@@ -101,15 +101,15 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = getenv('WORDPRESS_DB_HOST') ? explode(':', getenv('WORDPRESS_DB_HOST'), 2) : 'mysql';
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
-$user = getenv('WORDPRESS_DB_USER') ?: 'root';
-$pass = getenv('WORDPRESS_DB_PASSWORD') ?: '';
-$dbName = getenv('WORDPRESS_DB_NAME') ?: 'wordpress';
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 $maxTries = 10;
 do {
 	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);

--- a/latest/php8.0/fpm/docker-entrypoint.sh
+++ b/latest/php8.0/fpm/docker-entrypoint.sh
@@ -87,12 +87,12 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
-
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
+		export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+		export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+		export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-}
+		export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"wordpress"}
+
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/latest/php8.0/fpm/docker-entrypoint.sh
+++ b/latest/php8.0/fpm/docker-entrypoint.sh
@@ -87,7 +87,13 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	if ! TERM=dumb php -- <<'EOPHP'
+	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+
+	if [ -z ${SKIP_DB_CREATION+x} ] then
+		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)
 $stderr = fopen('php://stderr', 'w');
@@ -123,11 +129,12 @@ if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `' . $mysql->real_escape_strin
 }
 $mysql->close();
 EOPHP
-	then
-		echo >&2
-		echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
-		echo >&2 '  continuing anyways (which might have unexpected results)'
-		echo >&2
+		then
+			echo >&2
+			echo >&2 "WARNING: unable to establish a database connection to '$WORDPRESS_DB_HOST'"
+			echo >&2 '  continuing anyways (which might have unexpected results)'
+			echo >&2
+		fi
 	fi
 fi
 

--- a/latest/php8.0/fpm/docker-entrypoint.sh
+++ b/latest/php8.0/fpm/docker-entrypoint.sh
@@ -92,7 +92,7 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
 	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
-	if [ -z ${SKIP_DB_CREATION+x} ] then
+	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
 <?php
 // database might not exist, so let's try creating it (just to be safe)

--- a/latest/php8.0/fpm/docker-entrypoint.sh
+++ b/latest/php8.0/fpm/docker-entrypoint.sh
@@ -87,10 +87,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		done
 	fi
 
-	WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
-	WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
-	WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
-	WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
+	export WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST-"mysql"}
+	export WORDPRESS_DB_USER=${WORDPRESS_DB_USER-"root"}
+	export WORDPRESS_DB_PASSWORD=${WORDPRESS_DB_PASSWORD-""}
+	export WORDPRESS_DB_NAME=${WORDPRESS_DB_NAME-"mysql"}
 
 	if [ -z ${SKIP_DB_CREATION+x} ]; then
 		if ! TERM=dumb php -- <<'EOPHP'
@@ -101,15 +101,15 @@ $stderr = fopen('php://stderr', 'w');
 //   "hostname:port"
 // https://codex.wordpress.org/Editing_wp-config.php#MySQL_Sockets_or_Pipes
 //   "hostname:unix-socket-path"
-list($host, $socket) = getenv('WORDPRESS_DB_HOST') ? explode(':', getenv('WORDPRESS_DB_HOST'), 2) : 'mysql';
+list($host, $socket) = explode(':', getenv('WORDPRESS_DB_HOST'), 2);
 $port = 0;
 if (is_numeric($socket)) {
 	$port = (int) $socket;
 	$socket = null;
 }
-$user = getenv('WORDPRESS_DB_USER') ?: 'root';
-$pass = getenv('WORDPRESS_DB_PASSWORD') ?: '';
-$dbName = getenv('WORDPRESS_DB_NAME') ?: 'wordpress';
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$dbName = getenv('WORDPRESS_DB_NAME');
 $maxTries = 10;
 do {
 	$mysql = new mysqli($host, $user, $pass, '', $port, $socket);


### PR DESCRIPTION
[Removing the ability](https://github.com/docker-library/wordpress/pull/572/files?file-filters%5B%5D=.php&file-filters%5B%5D=.sh&file-filters%5B%5D=.template&file-filters%5B%5D=No+extension&hide-deleted-files=true#diff-79738685a656fe6b25061bb14181442210b599f746faeaba408a2401de45038aL263) to create the WordPress database on container startup has broken environments that rely on that feature (see https://github.com/WordPress/gutenberg/issues/29752 and https://github.com/ampproject/amp-wp/pull/5974 as examples). Because of this change users relying on this image will now have to customize the image to add tools such as [`wait-for-it`](https://github.com/vishnubob/wait-for-it) so that the container will wait on their MySQL container provision the database.

I'm not sure why this feature has been removed as there are no commits or comments explaining the need for the change, but I do hope this PR is accepted so that users of the image won't have to wake up to a broken environment :smile:.