### PR TITLE
Fix ownership of wp-config.php

### DIFF
--- a/beta/php7.3/apache/docker-entrypoint.sh
+++ b/beta/php7.3/apache/docker-entrypoint.sh
@@ -82,6 +82,11 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 					}
 					{ print }
 				' "$wpConfigDocker" > wp-config.php
+				if [ "$uid" = '0' ]; then
+					# attempt to ensure that wp-config.php is owned by the run user
+					# could be on a filesystem that doesn't allow chown (like some NFS setups)
+					chown "$user:$group" wp-config.php || true
+				fi
 				break
 			fi
 		done

--- a/beta/php7.3/fpm-alpine/docker-entrypoint.sh
+++ b/beta/php7.3/fpm-alpine/docker-entrypoint.sh
@@ -82,6 +82,11 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 					}
 					{ print }
 				' "$wpConfigDocker" > wp-config.php
+				if [ "$uid" = '0' ]; then
+					# attempt to ensure that wp-config.php is owned by the run user
+					# could be on a filesystem that doesn't allow chown (like some NFS setups)
+					chown "$user:$group" wp-config.php || true
+				fi
 				break
 			fi
 		done

--- a/beta/php7.3/fpm/docker-entrypoint.sh
+++ b/beta/php7.3/fpm/docker-entrypoint.sh
@@ -82,6 +82,11 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 					}
 					{ print }
 				' "$wpConfigDocker" > wp-config.php
+				if [ "$uid" = '0' ]; then
+					# attempt to ensure that wp-config.php is owned by the run user
+					# could be on a filesystem that doesn't allow chown (like some NFS setups)
+					chown "$user:$group" wp-config.php || true
+				fi
 				break
 			fi
 		done

--- a/beta/php7.4/apache/docker-entrypoint.sh
+++ b/beta/php7.4/apache/docker-entrypoint.sh
@@ -82,6 +82,11 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 					}
 					{ print }
 				' "$wpConfigDocker" > wp-config.php
+				if [ "$uid" = '0' ]; then
+					# attempt to ensure that wp-config.php is owned by the run user
+					# could be on a filesystem that doesn't allow chown (like some NFS setups)
+					chown "$user:$group" wp-config.php || true
+				fi
 				break
 			fi
 		done

--- a/beta/php7.4/fpm-alpine/docker-entrypoint.sh
+++ b/beta/php7.4/fpm-alpine/docker-entrypoint.sh
@@ -82,6 +82,11 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 					}
 					{ print }
 				' "$wpConfigDocker" > wp-config.php
+				if [ "$uid" = '0' ]; then
+					# attempt to ensure that wp-config.php is owned by the run user
+					# could be on a filesystem that doesn't allow chown (like some NFS setups)
+					chown "$user:$group" wp-config.php || true
+				fi
 				break
 			fi
 		done

--- a/beta/php7.4/fpm/docker-entrypoint.sh
+++ b/beta/php7.4/fpm/docker-entrypoint.sh
@@ -82,6 +82,11 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 					}
 					{ print }
 				' "$wpConfigDocker" > wp-config.php
+				if [ "$uid" = '0' ]; then
+					# attempt to ensure that wp-config.php is owned by the run user
+					# could be on a filesystem that doesn't allow chown (like some NFS setups)
+					chown "$user:$group" wp-config.php || true
+				fi
 				break
 			fi
 		done

--- a/beta/php8.0/apache/docker-entrypoint.sh
+++ b/beta/php8.0/apache/docker-entrypoint.sh
@@ -82,6 +82,11 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 					}
 					{ print }
 				' "$wpConfigDocker" > wp-config.php
+				if [ "$uid" = '0' ]; then
+					# attempt to ensure that wp-config.php is owned by the run user
+					# could be on a filesystem that doesn't allow chown (like some NFS setups)
+					chown "$user:$group" wp-config.php || true
+				fi
 				break
 			fi
 		done

--- a/beta/php8.0/fpm-alpine/docker-entrypoint.sh
+++ b/beta/php8.0/fpm-alpine/docker-entrypoint.sh
@@ -82,6 +82,11 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 					}
 					{ print }
 				' "$wpConfigDocker" > wp-config.php
+				if [ "$uid" = '0' ]; then
+					# attempt to ensure that wp-config.php is owned by the run user
+					# could be on a filesystem that doesn't allow chown (like some NFS setups)
+					chown "$user:$group" wp-config.php || true
+				fi
 				break
 			fi
 		done

--- a/beta/php8.0/fpm/docker-entrypoint.sh
+++ b/beta/php8.0/fpm/docker-entrypoint.sh
@@ -82,6 +82,11 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 					}
 					{ print }
 				' "$wpConfigDocker" > wp-config.php
+				if [ "$uid" = '0' ]; then
+					# attempt to ensure that wp-config.php is owned by the run user
+					# could be on a filesystem that doesn't allow chown (like some NFS setups)
+					chown "$user:$group" wp-config.php || true
+				fi
 				break
 			fi
 		done

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -82,6 +82,11 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 					}
 					{ print }
 				' "$wpConfigDocker" > wp-config.php
+				if [ "$uid" = '0' ]; then
+					# attempt to ensure that wp-config.php is owned by the run user
+					# could be on a filesystem that doesn't allow chown (like some NFS setups)
+					chown "$user:$group" wp-config.php || true
+				fi
 				break
 			fi
 		done

--- a/latest/php7.3/apache/docker-entrypoint.sh
+++ b/latest/php7.3/apache/docker-entrypoint.sh
@@ -82,6 +82,11 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 					}
 					{ print }
 				' "$wpConfigDocker" > wp-config.php
+				if [ "$uid" = '0' ]; then
+					# attempt to ensure that wp-config.php is owned by the run user
+					# could be on a filesystem that doesn't allow chown (like some NFS setups)
+					chown "$user:$group" wp-config.php || true
+				fi
 				break
 			fi
 		done

--- a/latest/php7.3/fpm-alpine/docker-entrypoint.sh
+++ b/latest/php7.3/fpm-alpine/docker-entrypoint.sh
@@ -82,6 +82,11 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 					}
 					{ print }
 				' "$wpConfigDocker" > wp-config.php
+				if [ "$uid" = '0' ]; then
+					# attempt to ensure that wp-config.php is owned by the run user
+					# could be on a filesystem that doesn't allow chown (like some NFS setups)
+					chown "$user:$group" wp-config.php || true
+				fi
 				break
 			fi
 		done

--- a/latest/php7.3/fpm/docker-entrypoint.sh
+++ b/latest/php7.3/fpm/docker-entrypoint.sh
@@ -82,6 +82,11 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 					}
 					{ print }
 				' "$wpConfigDocker" > wp-config.php
+				if [ "$uid" = '0' ]; then
+					# attempt to ensure that wp-config.php is owned by the run user
+					# could be on a filesystem that doesn't allow chown (like some NFS setups)
+					chown "$user:$group" wp-config.php || true
+				fi
 				break
 			fi
 		done

--- a/latest/php7.4/apache/docker-entrypoint.sh
+++ b/latest/php7.4/apache/docker-entrypoint.sh
@@ -82,6 +82,11 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 					}
 					{ print }
 				' "$wpConfigDocker" > wp-config.php
+				if [ "$uid" = '0' ]; then
+					# attempt to ensure that wp-config.php is owned by the run user
+					# could be on a filesystem that doesn't allow chown (like some NFS setups)
+					chown "$user:$group" wp-config.php || true
+				fi
 				break
 			fi
 		done

--- a/latest/php7.4/fpm-alpine/docker-entrypoint.sh
+++ b/latest/php7.4/fpm-alpine/docker-entrypoint.sh
@@ -82,6 +82,11 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 					}
 					{ print }
 				' "$wpConfigDocker" > wp-config.php
+				if [ "$uid" = '0' ]; then
+					# attempt to ensure that wp-config.php is owned by the run user
+					# could be on a filesystem that doesn't allow chown (like some NFS setups)
+					chown "$user:$group" wp-config.php || true
+				fi
 				break
 			fi
 		done

--- a/latest/php7.4/fpm/docker-entrypoint.sh
+++ b/latest/php7.4/fpm/docker-entrypoint.sh
@@ -82,6 +82,11 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 					}
 					{ print }
 				' "$wpConfigDocker" > wp-config.php
+				if [ "$uid" = '0' ]; then
+					# attempt to ensure that wp-config.php is owned by the run user
+					# could be on a filesystem that doesn't allow chown (like some NFS setups)
+					chown "$user:$group" wp-config.php || true
+				fi
 				break
 			fi
 		done

--- a/latest/php8.0/apache/docker-entrypoint.sh
+++ b/latest/php8.0/apache/docker-entrypoint.sh
@@ -82,6 +82,11 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 					}
 					{ print }
 				' "$wpConfigDocker" > wp-config.php
+				if [ "$uid" = '0' ]; then
+					# attempt to ensure that wp-config.php is owned by the run user
+					# could be on a filesystem that doesn't allow chown (like some NFS setups)
+					chown "$user:$group" wp-config.php || true
+				fi
 				break
 			fi
 		done

--- a/latest/php8.0/fpm-alpine/docker-entrypoint.sh
+++ b/latest/php8.0/fpm-alpine/docker-entrypoint.sh
@@ -82,6 +82,11 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 					}
 					{ print }
 				' "$wpConfigDocker" > wp-config.php
+				if [ "$uid" = '0' ]; then
+					# attempt to ensure that wp-config.php is owned by the run user
+					# could be on a filesystem that doesn't allow chown (like some NFS setups)
+					chown "$user:$group" wp-config.php || true
+				fi
 				break
 			fi
 		done

--- a/latest/php8.0/fpm/docker-entrypoint.sh
+++ b/latest/php8.0/fpm/docker-entrypoint.sh
@@ -82,6 +82,11 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 					}
 					{ print }
 				' "$wpConfigDocker" > wp-config.php
+				if [ "$uid" = '0' ]; then
+					# attempt to ensure that wp-config.php is owned by the run user
+					# could be on a filesystem that doesn't allow chown (like some NFS setups)
+					chown "$user:$group" wp-config.php || true
+				fi
 				break
 			fi
 		done


### PR DESCRIPTION
fixes #586

(doesn't effect current deployments, only when `wp-config-docker.php` is copied over)