### PR TITLE
Redirect to HTTPS without a trailing slash

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -185,6 +185,10 @@ RUN set -eux; \
 		echo 'RewriteEngine On'; \
 		echo 'RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]'; \
 		echo 'RewriteBase /'; \
+		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
+		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
+    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -187,8 +187,8 @@ RUN set -eux; \
 		echo 'RewriteBase /'; \
 		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
 		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
-    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
-    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
+		echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+		echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/beta/php7.3/apache/Dockerfile
+++ b/beta/php7.3/apache/Dockerfile
@@ -126,8 +126,8 @@ RUN set -eux; \
 		echo 'RewriteBase /'; \
 		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
 		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
-    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
-    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
+		echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+		echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/beta/php7.3/apache/Dockerfile
+++ b/beta/php7.3/apache/Dockerfile
@@ -124,6 +124,10 @@ RUN set -eux; \
 		echo 'RewriteEngine On'; \
 		echo 'RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]'; \
 		echo 'RewriteBase /'; \
+		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
+		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
+    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/beta/php7.3/fpm-alpine/Dockerfile
+++ b/beta/php7.3/fpm-alpine/Dockerfile
@@ -101,6 +101,10 @@ RUN set -eux; \
 		echo 'RewriteEngine On'; \
 		echo 'RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]'; \
 		echo 'RewriteBase /'; \
+		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
+		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
+    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/beta/php7.3/fpm-alpine/Dockerfile
+++ b/beta/php7.3/fpm-alpine/Dockerfile
@@ -103,8 +103,8 @@ RUN set -eux; \
 		echo 'RewriteBase /'; \
 		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
 		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
-    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
-    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
+		echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+		echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/beta/php7.3/fpm/Dockerfile
+++ b/beta/php7.3/fpm/Dockerfile
@@ -107,8 +107,8 @@ RUN set -eux; \
 		echo 'RewriteBase /'; \
 		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
 		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
-    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
-    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
+		echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+		echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/beta/php7.3/fpm/Dockerfile
+++ b/beta/php7.3/fpm/Dockerfile
@@ -105,6 +105,10 @@ RUN set -eux; \
 		echo 'RewriteEngine On'; \
 		echo 'RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]'; \
 		echo 'RewriteBase /'; \
+		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
+		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
+    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/beta/php7.4/apache/Dockerfile
+++ b/beta/php7.4/apache/Dockerfile
@@ -123,6 +123,10 @@ RUN set -eux; \
 		echo 'RewriteEngine On'; \
 		echo 'RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]'; \
 		echo 'RewriteBase /'; \
+		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
+		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
+    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/beta/php7.4/apache/Dockerfile
+++ b/beta/php7.4/apache/Dockerfile
@@ -125,8 +125,8 @@ RUN set -eux; \
 		echo 'RewriteBase /'; \
 		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
 		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
-    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
-    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
+		echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+		echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/beta/php7.4/fpm-alpine/Dockerfile
+++ b/beta/php7.4/fpm-alpine/Dockerfile
@@ -100,6 +100,10 @@ RUN set -eux; \
 		echo 'RewriteEngine On'; \
 		echo 'RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]'; \
 		echo 'RewriteBase /'; \
+		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
+		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
+    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/beta/php7.4/fpm-alpine/Dockerfile
+++ b/beta/php7.4/fpm-alpine/Dockerfile
@@ -102,8 +102,8 @@ RUN set -eux; \
 		echo 'RewriteBase /'; \
 		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
 		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
-    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
-    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
+		echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+		echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/beta/php7.4/fpm/Dockerfile
+++ b/beta/php7.4/fpm/Dockerfile
@@ -104,6 +104,10 @@ RUN set -eux; \
 		echo 'RewriteEngine On'; \
 		echo 'RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]'; \
 		echo 'RewriteBase /'; \
+		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
+		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
+    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/beta/php7.4/fpm/Dockerfile
+++ b/beta/php7.4/fpm/Dockerfile
@@ -106,8 +106,8 @@ RUN set -eux; \
 		echo 'RewriteBase /'; \
 		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
 		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
-    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
-    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
+		echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+		echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/beta/php8.0/apache/Dockerfile
+++ b/beta/php8.0/apache/Dockerfile
@@ -123,6 +123,10 @@ RUN set -eux; \
 		echo 'RewriteEngine On'; \
 		echo 'RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]'; \
 		echo 'RewriteBase /'; \
+		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
+		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
+    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/beta/php8.0/apache/Dockerfile
+++ b/beta/php8.0/apache/Dockerfile
@@ -125,8 +125,8 @@ RUN set -eux; \
 		echo 'RewriteBase /'; \
 		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
 		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
-    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
-    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
+		echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+		echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/beta/php8.0/fpm-alpine/Dockerfile
+++ b/beta/php8.0/fpm-alpine/Dockerfile
@@ -100,6 +100,10 @@ RUN set -eux; \
 		echo 'RewriteEngine On'; \
 		echo 'RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]'; \
 		echo 'RewriteBase /'; \
+		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
+		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
+    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/beta/php8.0/fpm-alpine/Dockerfile
+++ b/beta/php8.0/fpm-alpine/Dockerfile
@@ -102,8 +102,8 @@ RUN set -eux; \
 		echo 'RewriteBase /'; \
 		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
 		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
-    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
-    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
+		echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+		echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/beta/php8.0/fpm/Dockerfile
+++ b/beta/php8.0/fpm/Dockerfile
@@ -104,6 +104,10 @@ RUN set -eux; \
 		echo 'RewriteEngine On'; \
 		echo 'RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]'; \
 		echo 'RewriteBase /'; \
+		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
+		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
+    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/beta/php8.0/fpm/Dockerfile
+++ b/beta/php8.0/fpm/Dockerfile
@@ -106,8 +106,8 @@ RUN set -eux; \
 		echo 'RewriteBase /'; \
 		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
 		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
-    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
-    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
+		echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+		echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/latest/php7.3/apache/Dockerfile
+++ b/latest/php7.3/apache/Dockerfile
@@ -126,8 +126,8 @@ RUN set -eux; \
 		echo 'RewriteBase /'; \
 		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
 		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
-    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
-    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
+		echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+		echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/latest/php7.3/apache/Dockerfile
+++ b/latest/php7.3/apache/Dockerfile
@@ -124,6 +124,10 @@ RUN set -eux; \
 		echo 'RewriteEngine On'; \
 		echo 'RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]'; \
 		echo 'RewriteBase /'; \
+		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
+		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
+    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/latest/php7.3/fpm-alpine/Dockerfile
+++ b/latest/php7.3/fpm-alpine/Dockerfile
@@ -101,6 +101,10 @@ RUN set -eux; \
 		echo 'RewriteEngine On'; \
 		echo 'RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]'; \
 		echo 'RewriteBase /'; \
+		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
+		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
+    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/latest/php7.3/fpm-alpine/Dockerfile
+++ b/latest/php7.3/fpm-alpine/Dockerfile
@@ -103,8 +103,8 @@ RUN set -eux; \
 		echo 'RewriteBase /'; \
 		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
 		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
-    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
-    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
+		echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+		echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/latest/php7.3/fpm/Dockerfile
+++ b/latest/php7.3/fpm/Dockerfile
@@ -107,8 +107,8 @@ RUN set -eux; \
 		echo 'RewriteBase /'; \
 		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
 		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
-    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
-    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
+		echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+		echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/latest/php7.3/fpm/Dockerfile
+++ b/latest/php7.3/fpm/Dockerfile
@@ -105,6 +105,10 @@ RUN set -eux; \
 		echo 'RewriteEngine On'; \
 		echo 'RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]'; \
 		echo 'RewriteBase /'; \
+		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
+		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
+    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/latest/php7.4/apache/Dockerfile
+++ b/latest/php7.4/apache/Dockerfile
@@ -123,6 +123,10 @@ RUN set -eux; \
 		echo 'RewriteEngine On'; \
 		echo 'RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]'; \
 		echo 'RewriteBase /'; \
+		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
+		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
+    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/latest/php7.4/apache/Dockerfile
+++ b/latest/php7.4/apache/Dockerfile
@@ -125,8 +125,8 @@ RUN set -eux; \
 		echo 'RewriteBase /'; \
 		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
 		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
-    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
-    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
+		echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+		echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/latest/php7.4/fpm-alpine/Dockerfile
+++ b/latest/php7.4/fpm-alpine/Dockerfile
@@ -100,6 +100,10 @@ RUN set -eux; \
 		echo 'RewriteEngine On'; \
 		echo 'RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]'; \
 		echo 'RewriteBase /'; \
+		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
+		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
+    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/latest/php7.4/fpm-alpine/Dockerfile
+++ b/latest/php7.4/fpm-alpine/Dockerfile
@@ -102,8 +102,8 @@ RUN set -eux; \
 		echo 'RewriteBase /'; \
 		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
 		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
-    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
-    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
+		echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+		echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/latest/php7.4/fpm/Dockerfile
+++ b/latest/php7.4/fpm/Dockerfile
@@ -104,6 +104,10 @@ RUN set -eux; \
 		echo 'RewriteEngine On'; \
 		echo 'RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]'; \
 		echo 'RewriteBase /'; \
+		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
+		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
+    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/latest/php7.4/fpm/Dockerfile
+++ b/latest/php7.4/fpm/Dockerfile
@@ -106,8 +106,8 @@ RUN set -eux; \
 		echo 'RewriteBase /'; \
 		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
 		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
-    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
-    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
+		echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+		echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/latest/php8.0/apache/Dockerfile
+++ b/latest/php8.0/apache/Dockerfile
@@ -123,6 +123,10 @@ RUN set -eux; \
 		echo 'RewriteEngine On'; \
 		echo 'RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]'; \
 		echo 'RewriteBase /'; \
+		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
+		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
+    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/latest/php8.0/apache/Dockerfile
+++ b/latest/php8.0/apache/Dockerfile
@@ -125,8 +125,8 @@ RUN set -eux; \
 		echo 'RewriteBase /'; \
 		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
 		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
-    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
-    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
+		echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+		echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/latest/php8.0/fpm-alpine/Dockerfile
+++ b/latest/php8.0/fpm-alpine/Dockerfile
@@ -100,6 +100,10 @@ RUN set -eux; \
 		echo 'RewriteEngine On'; \
 		echo 'RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]'; \
 		echo 'RewriteBase /'; \
+		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
+		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
+    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/latest/php8.0/fpm-alpine/Dockerfile
+++ b/latest/php8.0/fpm-alpine/Dockerfile
@@ -102,8 +102,8 @@ RUN set -eux; \
 		echo 'RewriteBase /'; \
 		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
 		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
-    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
-    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
+		echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+		echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/latest/php8.0/fpm/Dockerfile
+++ b/latest/php8.0/fpm/Dockerfile
@@ -104,6 +104,10 @@ RUN set -eux; \
 		echo 'RewriteEngine On'; \
 		echo 'RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]'; \
 		echo 'RewriteBase /'; \
+		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
+		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
+    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \

--- a/latest/php8.0/fpm/Dockerfile
+++ b/latest/php8.0/fpm/Dockerfile
@@ -106,8 +106,8 @@ RUN set -eux; \
 		echo 'RewriteBase /'; \
 		echo 'RewriteCond %{LA-U:REQUEST_FILENAME} -d'; \
 		echo 'RewriteCond %{REQUEST_URI} !(.*)/$'; \
-    	echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
-    	echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
+		echo 'RewriteCond %{HTTP:X-Forwarded-Proto} https'; \
+		echo 'RewriteRule ^.*$ https://%{HTTP_HOST}%{REQUEST_URI}/ [L,R=301,QSA]'; \
 		echo 'RewriteRule ^index\.php$ - [L]'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-f'; \
 		echo 'RewriteCond %{REQUEST_FILENAME} !-d'; \


### PR DESCRIPTION
The mod_dir redirects https://example.com/wp-admin to http://example.com/wp-admin/ when the apache is behind an HTTPS reverse proxy because the Location header requires the scheme and the apache didn't consider X-Forwarded-Proto.

This rewrite rule in this htaccess will add a trailing slash with the correct scheme.

Ref: https://serverfault.com/a/851918
Ref: https://stackoverflow.com/a/40447815

%{LA-U:REQUEST_FILENAME} will access the server via mod_dir and check if the resulted URL is a directory.