### PR TITLE
Add Apache port option for user

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -96,4 +96,13 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 	fi
 fi
 
+if [[ "$1" == apache2* ]]; then
+	if [ -n "${APACHE_PORT+x}" ]; then
+	    echo "Setting apache port to ${APACHE_PORT}."
+	    sed -i "s/VirtualHost \*:80/VirtualHost \*:${APACHE_PORT}/g" /etc/apache2/sites-enabled/000-default.conf
+	    sed -i "s/Listen 80/Listen ${APACHE_PORT}/g" /etc/apache2/ports.conf
+	    apachectl configtest
+	fi
+fi
+
 exec "$@"


### PR DESCRIPTION
Hi,

As you know many people need to run container with different port, instead of default port 80. For instance one of those situations is deploying on Openshift cluster, in Openshift you cannot use privileged ports ( Under 1024 ) by default. Hence I have added an option for Apache port in the entrypoint that user can change it using APACHE_PORT variable.

Kind regards