### PR TITLE
add: Redis Extension Support

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -85,8 +85,8 @@ RUN set -ex; \
 # WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
 {{ ) else "" end -}}
 # https://pecl.php.net/package/imagick
-	pecl install imagick-3.6.0; \
-	docker-php-ext-enable imagick; \
+	pecl install redis imagick-3.6.0; \
+	docker-php-ext-enable redis imagick; \
 	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)

--- a/beta/php8.0/apache/Dockerfile
+++ b/beta/php8.0/apache/Dockerfile
@@ -45,8 +45,8 @@ RUN set -ex; \
 		zip \
 	; \
 # https://pecl.php.net/package/imagick
-	pecl install imagick-3.6.0; \
-	docker-php-ext-enable imagick; \
+	pecl install redis imagick-3.6.0; \
+	docker-php-ext-enable redis imagick; \
 	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)

--- a/beta/php8.0/fpm-alpine/Dockerfile
+++ b/beta/php8.0/fpm-alpine/Dockerfile
@@ -46,8 +46,8 @@ RUN set -ex; \
 	; \
 # WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
 # https://pecl.php.net/package/imagick
-	pecl install imagick-3.6.0; \
-	docker-php-ext-enable imagick; \
+	pecl install redis imagick-3.6.0; \
+	docker-php-ext-enable redis imagick; \
 	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)

--- a/beta/php8.0/fpm/Dockerfile
+++ b/beta/php8.0/fpm/Dockerfile
@@ -45,8 +45,8 @@ RUN set -ex; \
 		zip \
 	; \
 # https://pecl.php.net/package/imagick
-	pecl install imagick-3.6.0; \
-	docker-php-ext-enable imagick; \
+	pecl install redis imagick-3.6.0; \
+	docker-php-ext-enable redis imagick; \
 	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)

--- a/beta/php8.1/apache/Dockerfile
+++ b/beta/php8.1/apache/Dockerfile
@@ -45,8 +45,8 @@ RUN set -ex; \
 		zip \
 	; \
 # https://pecl.php.net/package/imagick
-	pecl install imagick-3.6.0; \
-	docker-php-ext-enable imagick; \
+	pecl install redis imagick-3.6.0; \
+	docker-php-ext-enable redis imagick; \
 	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)

--- a/beta/php8.1/fpm-alpine/Dockerfile
+++ b/beta/php8.1/fpm-alpine/Dockerfile
@@ -46,8 +46,8 @@ RUN set -ex; \
 	; \
 # WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
 # https://pecl.php.net/package/imagick
-	pecl install imagick-3.6.0; \
-	docker-php-ext-enable imagick; \
+	pecl install redis imagick-3.6.0; \
+	docker-php-ext-enable redis imagick; \
 	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)

--- a/beta/php8.1/fpm/Dockerfile
+++ b/beta/php8.1/fpm/Dockerfile
@@ -45,8 +45,8 @@ RUN set -ex; \
 		zip \
 	; \
 # https://pecl.php.net/package/imagick
-	pecl install imagick-3.6.0; \
-	docker-php-ext-enable imagick; \
+	pecl install redis imagick-3.6.0; \
+	docker-php-ext-enable redis imagick; \
 	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)

--- a/beta/php8.2/apache/Dockerfile
+++ b/beta/php8.2/apache/Dockerfile
@@ -45,8 +45,8 @@ RUN set -ex; \
 		zip \
 	; \
 # https://pecl.php.net/package/imagick
-	pecl install imagick-3.6.0; \
-	docker-php-ext-enable imagick; \
+	pecl install redis imagick-3.6.0; \
+	docker-php-ext-enable redis imagick; \
 	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)

--- a/beta/php8.2/fpm-alpine/Dockerfile
+++ b/beta/php8.2/fpm-alpine/Dockerfile
@@ -46,8 +46,8 @@ RUN set -ex; \
 	; \
 # WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
 # https://pecl.php.net/package/imagick
-	pecl install imagick-3.6.0; \
-	docker-php-ext-enable imagick; \
+	pecl install redis imagick-3.6.0; \
+	docker-php-ext-enable redis imagick; \
 	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)

--- a/beta/php8.2/fpm/Dockerfile
+++ b/beta/php8.2/fpm/Dockerfile
@@ -45,8 +45,8 @@ RUN set -ex; \
 		zip \
 	; \
 # https://pecl.php.net/package/imagick
-	pecl install imagick-3.6.0; \
-	docker-php-ext-enable imagick; \
+	pecl install redis imagick-3.6.0; \
+	docker-php-ext-enable redis imagick; \
 	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)

--- a/cli/php8.0/alpine/Dockerfile
+++ b/cli/php8.0/alpine/Dockerfile
@@ -47,8 +47,8 @@ RUN set -ex; \
 	; \
 # WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
 # https://pecl.php.net/package/imagick
-	pecl install imagick-3.6.0; \
-	docker-php-ext-enable imagick; \
+	pecl install redis imagick-3.6.0; \
+	docker-php-ext-enable redis imagick; \
 	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)

--- a/cli/php8.1/alpine/Dockerfile
+++ b/cli/php8.1/alpine/Dockerfile
@@ -47,8 +47,8 @@ RUN set -ex; \
 	; \
 # WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
 # https://pecl.php.net/package/imagick
-	pecl install imagick-3.6.0; \
-	docker-php-ext-enable imagick; \
+	pecl install redis imagick-3.6.0; \
+	docker-php-ext-enable redis imagick; \
 	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)

--- a/cli/php8.2/alpine/Dockerfile
+++ b/cli/php8.2/alpine/Dockerfile
@@ -47,8 +47,8 @@ RUN set -ex; \
 	; \
 # WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
 # https://pecl.php.net/package/imagick
-	pecl install imagick-3.6.0; \
-	docker-php-ext-enable imagick; \
+	pecl install redis imagick-3.6.0; \
+	docker-php-ext-enable redis imagick; \
 	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)

--- a/latest/php8.0/apache/Dockerfile
+++ b/latest/php8.0/apache/Dockerfile
@@ -45,8 +45,8 @@ RUN set -ex; \
 		zip \
 	; \
 # https://pecl.php.net/package/imagick
-	pecl install imagick-3.6.0; \
-	docker-php-ext-enable imagick; \
+	pecl install redis imagick-3.6.0; \
+	docker-php-ext-enable redis imagick; \
 	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)

--- a/latest/php8.0/fpm-alpine/Dockerfile
+++ b/latest/php8.0/fpm-alpine/Dockerfile
@@ -46,8 +46,8 @@ RUN set -ex; \
 	; \
 # WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
 # https://pecl.php.net/package/imagick
-	pecl install imagick-3.6.0; \
-	docker-php-ext-enable imagick; \
+	pecl install redis imagick-3.6.0; \
+	docker-php-ext-enable redis imagick; \
 	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)

--- a/latest/php8.0/fpm/Dockerfile
+++ b/latest/php8.0/fpm/Dockerfile
@@ -45,8 +45,8 @@ RUN set -ex; \
 		zip \
 	; \
 # https://pecl.php.net/package/imagick
-	pecl install imagick-3.6.0; \
-	docker-php-ext-enable imagick; \
+	pecl install redis imagick-3.6.0; \
+	docker-php-ext-enable redis imagick; \
 	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)

--- a/latest/php8.1/apache/Dockerfile
+++ b/latest/php8.1/apache/Dockerfile
@@ -45,8 +45,8 @@ RUN set -ex; \
 		zip \
 	; \
 # https://pecl.php.net/package/imagick
-	pecl install imagick-3.6.0; \
-	docker-php-ext-enable imagick; \
+	pecl install redis imagick-3.6.0; \
+	docker-php-ext-enable redis imagick; \
 	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)

--- a/latest/php8.1/fpm-alpine/Dockerfile
+++ b/latest/php8.1/fpm-alpine/Dockerfile
@@ -46,8 +46,8 @@ RUN set -ex; \
 	; \
 # WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
 # https://pecl.php.net/package/imagick
-	pecl install imagick-3.6.0; \
-	docker-php-ext-enable imagick; \
+	pecl install redis imagick-3.6.0; \
+	docker-php-ext-enable redis imagick; \
 	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)

--- a/latest/php8.1/fpm/Dockerfile
+++ b/latest/php8.1/fpm/Dockerfile
@@ -45,8 +45,8 @@ RUN set -ex; \
 		zip \
 	; \
 # https://pecl.php.net/package/imagick
-	pecl install imagick-3.6.0; \
-	docker-php-ext-enable imagick; \
+	pecl install redis imagick-3.6.0; \
+	docker-php-ext-enable redis imagick; \
 	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)

--- a/latest/php8.2/apache/Dockerfile
+++ b/latest/php8.2/apache/Dockerfile
@@ -45,8 +45,8 @@ RUN set -ex; \
 		zip \
 	; \
 # https://pecl.php.net/package/imagick
-	pecl install imagick-3.6.0; \
-	docker-php-ext-enable imagick; \
+	pecl install redis imagick-3.6.0; \
+	docker-php-ext-enable redis imagick; \
 	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)

--- a/latest/php8.2/fpm-alpine/Dockerfile
+++ b/latest/php8.2/fpm-alpine/Dockerfile
@@ -46,8 +46,8 @@ RUN set -ex; \
 	; \
 # WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
 # https://pecl.php.net/package/imagick
-	pecl install imagick-3.6.0; \
-	docker-php-ext-enable imagick; \
+	pecl install redis imagick-3.6.0; \
+	docker-php-ext-enable redis imagick; \
 	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)

--- a/latest/php8.2/fpm/Dockerfile
+++ b/latest/php8.2/fpm/Dockerfile
@@ -45,8 +45,8 @@ RUN set -ex; \
 		zip \
 	; \
 # https://pecl.php.net/package/imagick
-	pecl install imagick-3.6.0; \
-	docker-php-ext-enable imagick; \
+	pecl install redis imagick-3.6.0; \
+	docker-php-ext-enable redis imagick; \
 	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)


### PR DESCRIPTION
I know it is not required for standard installation, but in most cases it can be difficult for the uninitiated to install. It would be very helpful if it came pre-installed.