### PR TITLE
Support reproducible builds (except packages)

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -4,6 +4,10 @@
 -}}
 FROM php:{{ env.phpVersion }}-{{ env.variant }}
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 {{ if env.version != "cli" then ( -}}
 # persistent dependencies
 {{ if is_alpine then ( -}}
@@ -15,7 +19,9 @@ RUN set -eux; \
 		ghostscript \
 # Alpine package for "imagemagick" contains ~120 .so files, see: https://github.com/docker-library/wordpress/pull/497
 		imagemagick \
-	;
+	; \
+# clean up for reproducibility
+	rm -rf /var/cache/fontconfig
 {{ ) else ( -}}
 RUN set -eux; \
 	apt-get update; \
@@ -23,7 +29,9 @@ RUN set -eux; \
 # Ghostscript is required for rendering PDF previews
 		ghostscript \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/* ; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache
 {{ ) end -}}
 {{ ) else ( -}}
 # install wp-cli dependencies
@@ -43,7 +51,7 @@ WORKDIR /var/www/html
 RUN set -ex; \
 	\
 {{ if is_alpine then ( -}}
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache --virtual .build-deps=0 \
 		$PHPIZE_DEPS \
 		freetype-dev \
 		icu-dev \
@@ -123,7 +131,7 @@ RUN set -ex; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --no-network --virtual .wordpress-phpexts-rundeps $runDeps; \
+	apk add --no-network --virtual .wordpress-phpexts-rundeps=0 $runDeps; \
 	apk del --no-network .build-deps; \
 {{ ) else ( -}}
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
@@ -139,6 +147,8 @@ RUN set -ex; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache; \
 {{ ) end -}}
 	\
 	! { ldd "$extDir"/*.so | grep 'not found'; }; \
@@ -247,7 +257,7 @@ ENV WORDPRESS_CLI_SHA512 {{ .sha512 }}
 
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .fetch-deps \
+	apk add --no-cache --virtual .fetch-deps=0 \
 		gnupg \
 	; \
 	\

--- a/beta/php8.1/apache/Dockerfile
+++ b/beta/php8.1/apache/Dockerfile
@@ -6,6 +6,10 @@
 
 FROM php:8.1-apache
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 # persistent dependencies
 RUN set -eux; \
 	apt-get update; \
@@ -13,7 +17,9 @@ RUN set -eux; \
 # Ghostscript is required for rendering PDF previews
 		ghostscript \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/* ; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
@@ -81,6 +87,8 @@ RUN set -ex; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache; \
 	\
 	! { ldd "$extDir"/*.so | grep 'not found'; }; \
 # check for output like "PHP Warning:  PHP Startup: Unable to load dynamic library 'foo' (tried: ...)

--- a/beta/php8.1/fpm-alpine/Dockerfile
+++ b/beta/php8.1/fpm-alpine/Dockerfile
@@ -6,6 +6,10 @@
 
 FROM php:8.1-fpm-alpine
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 # persistent dependencies
 RUN set -eux; \
 	apk add --no-cache \
@@ -15,12 +19,14 @@ RUN set -eux; \
 		ghostscript \
 # Alpine package for "imagemagick" contains ~120 .so files, see: https://github.com/docker-library/wordpress/pull/497
 		imagemagick \
-	;
+	; \
+# clean up for reproducibility
+	rm -rf /var/cache/fontconfig
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache --virtual .build-deps=0 \
 		$PHPIZE_DEPS \
 		freetype-dev \
 		icu-dev \
@@ -75,7 +81,7 @@ RUN set -ex; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --no-network --virtual .wordpress-phpexts-rundeps $runDeps; \
+	apk add --no-network --virtual .wordpress-phpexts-rundeps=0 $runDeps; \
 	apk del --no-network .build-deps; \
 	\
 	! { ldd "$extDir"/*.so | grep 'not found'; }; \

--- a/beta/php8.1/fpm/Dockerfile
+++ b/beta/php8.1/fpm/Dockerfile
@@ -6,6 +6,10 @@
 
 FROM php:8.1-fpm
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 # persistent dependencies
 RUN set -eux; \
 	apt-get update; \
@@ -13,7 +17,9 @@ RUN set -eux; \
 # Ghostscript is required for rendering PDF previews
 		ghostscript \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/* ; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
@@ -81,6 +87,8 @@ RUN set -ex; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache; \
 	\
 	! { ldd "$extDir"/*.so | grep 'not found'; }; \
 # check for output like "PHP Warning:  PHP Startup: Unable to load dynamic library 'foo' (tried: ...)

--- a/beta/php8.2/apache/Dockerfile
+++ b/beta/php8.2/apache/Dockerfile
@@ -6,6 +6,10 @@
 
 FROM php:8.2-apache
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 # persistent dependencies
 RUN set -eux; \
 	apt-get update; \
@@ -13,7 +17,9 @@ RUN set -eux; \
 # Ghostscript is required for rendering PDF previews
 		ghostscript \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/* ; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
@@ -81,6 +87,8 @@ RUN set -ex; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache; \
 	\
 	! { ldd "$extDir"/*.so | grep 'not found'; }; \
 # check for output like "PHP Warning:  PHP Startup: Unable to load dynamic library 'foo' (tried: ...)

--- a/beta/php8.2/fpm-alpine/Dockerfile
+++ b/beta/php8.2/fpm-alpine/Dockerfile
@@ -6,6 +6,10 @@
 
 FROM php:8.2-fpm-alpine
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 # persistent dependencies
 RUN set -eux; \
 	apk add --no-cache \
@@ -15,12 +19,14 @@ RUN set -eux; \
 		ghostscript \
 # Alpine package for "imagemagick" contains ~120 .so files, see: https://github.com/docker-library/wordpress/pull/497
 		imagemagick \
-	;
+	; \
+# clean up for reproducibility
+	rm -rf /var/cache/fontconfig
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache --virtual .build-deps=0 \
 		$PHPIZE_DEPS \
 		freetype-dev \
 		icu-dev \
@@ -75,7 +81,7 @@ RUN set -ex; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --no-network --virtual .wordpress-phpexts-rundeps $runDeps; \
+	apk add --no-network --virtual .wordpress-phpexts-rundeps=0 $runDeps; \
 	apk del --no-network .build-deps; \
 	\
 	! { ldd "$extDir"/*.so | grep 'not found'; }; \

--- a/beta/php8.2/fpm/Dockerfile
+++ b/beta/php8.2/fpm/Dockerfile
@@ -6,6 +6,10 @@
 
 FROM php:8.2-fpm
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 # persistent dependencies
 RUN set -eux; \
 	apt-get update; \
@@ -13,7 +17,9 @@ RUN set -eux; \
 # Ghostscript is required for rendering PDF previews
 		ghostscript \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/* ; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
@@ -81,6 +87,8 @@ RUN set -ex; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache; \
 	\
 	! { ldd "$extDir"/*.so | grep 'not found'; }; \
 # check for output like "PHP Warning:  PHP Startup: Unable to load dynamic library 'foo' (tried: ...)

--- a/beta/php8.3/apache/Dockerfile
+++ b/beta/php8.3/apache/Dockerfile
@@ -6,6 +6,10 @@
 
 FROM php:8.3-apache
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 # persistent dependencies
 RUN set -eux; \
 	apt-get update; \
@@ -13,7 +17,9 @@ RUN set -eux; \
 # Ghostscript is required for rendering PDF previews
 		ghostscript \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/* ; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
@@ -81,6 +87,8 @@ RUN set -ex; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache; \
 	\
 	! { ldd "$extDir"/*.so | grep 'not found'; }; \
 # check for output like "PHP Warning:  PHP Startup: Unable to load dynamic library 'foo' (tried: ...)

--- a/beta/php8.3/fpm-alpine/Dockerfile
+++ b/beta/php8.3/fpm-alpine/Dockerfile
@@ -6,6 +6,10 @@
 
 FROM php:8.3-fpm-alpine
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 # persistent dependencies
 RUN set -eux; \
 	apk add --no-cache \
@@ -15,12 +19,14 @@ RUN set -eux; \
 		ghostscript \
 # Alpine package for "imagemagick" contains ~120 .so files, see: https://github.com/docker-library/wordpress/pull/497
 		imagemagick \
-	;
+	; \
+# clean up for reproducibility
+	rm -rf /var/cache/fontconfig
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache --virtual .build-deps=0 \
 		$PHPIZE_DEPS \
 		freetype-dev \
 		icu-dev \
@@ -75,7 +81,7 @@ RUN set -ex; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --no-network --virtual .wordpress-phpexts-rundeps $runDeps; \
+	apk add --no-network --virtual .wordpress-phpexts-rundeps=0 $runDeps; \
 	apk del --no-network .build-deps; \
 	\
 	! { ldd "$extDir"/*.so | grep 'not found'; }; \

--- a/beta/php8.3/fpm/Dockerfile
+++ b/beta/php8.3/fpm/Dockerfile
@@ -6,6 +6,10 @@
 
 FROM php:8.3-fpm
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 # persistent dependencies
 RUN set -eux; \
 	apt-get update; \
@@ -13,7 +17,9 @@ RUN set -eux; \
 # Ghostscript is required for rendering PDF previews
 		ghostscript \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/* ; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
@@ -81,6 +87,8 @@ RUN set -ex; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache; \
 	\
 	! { ldd "$extDir"/*.so | grep 'not found'; }; \
 # check for output like "PHP Warning:  PHP Startup: Unable to load dynamic library 'foo' (tried: ...)

--- a/cli/php8.1/alpine/Dockerfile
+++ b/cli/php8.1/alpine/Dockerfile
@@ -6,6 +6,10 @@
 
 FROM php:8.1-alpine
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 # install wp-cli dependencies
 RUN apk add --no-cache \
 # bash is needed for 'wp shell': https://github.com/wp-cli/shell-command/blob/b8dafcc2a2eba5732fdee70be077675a302848e9/src/WP_CLI/REPL.php#L104
@@ -21,7 +25,7 @@ WORKDIR /var/www/html
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache --virtual .build-deps=0 \
 		$PHPIZE_DEPS \
 		freetype-dev \
 		icu-dev \
@@ -76,7 +80,7 @@ RUN set -ex; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --no-network --virtual .wordpress-phpexts-rundeps $runDeps; \
+	apk add --no-network --virtual .wordpress-phpexts-rundeps=0 $runDeps; \
 	apk del --no-network .build-deps; \
 	\
 	! { ldd "$extDir"/*.so | grep 'not found'; }; \
@@ -113,7 +117,7 @@ ENV WORDPRESS_CLI_SHA512 adb12146bab8d829621efed41124dcd0012f9027f47e0228be70802
 
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .fetch-deps \
+	apk add --no-cache --virtual .fetch-deps=0 \
 		gnupg \
 	; \
 	\

--- a/cli/php8.2/alpine/Dockerfile
+++ b/cli/php8.2/alpine/Dockerfile
@@ -6,6 +6,10 @@
 
 FROM php:8.2-alpine
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 # install wp-cli dependencies
 RUN apk add --no-cache \
 # bash is needed for 'wp shell': https://github.com/wp-cli/shell-command/blob/b8dafcc2a2eba5732fdee70be077675a302848e9/src/WP_CLI/REPL.php#L104
@@ -21,7 +25,7 @@ WORKDIR /var/www/html
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache --virtual .build-deps=0 \
 		$PHPIZE_DEPS \
 		freetype-dev \
 		icu-dev \
@@ -76,7 +80,7 @@ RUN set -ex; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --no-network --virtual .wordpress-phpexts-rundeps $runDeps; \
+	apk add --no-network --virtual .wordpress-phpexts-rundeps=0 $runDeps; \
 	apk del --no-network .build-deps; \
 	\
 	! { ldd "$extDir"/*.so | grep 'not found'; }; \
@@ -113,7 +117,7 @@ ENV WORDPRESS_CLI_SHA512 adb12146bab8d829621efed41124dcd0012f9027f47e0228be70802
 
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .fetch-deps \
+	apk add --no-cache --virtual .fetch-deps=0 \
 		gnupg \
 	; \
 	\

--- a/cli/php8.3/alpine/Dockerfile
+++ b/cli/php8.3/alpine/Dockerfile
@@ -6,6 +6,10 @@
 
 FROM php:8.3-alpine
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 # install wp-cli dependencies
 RUN apk add --no-cache \
 # bash is needed for 'wp shell': https://github.com/wp-cli/shell-command/blob/b8dafcc2a2eba5732fdee70be077675a302848e9/src/WP_CLI/REPL.php#L104
@@ -21,7 +25,7 @@ WORKDIR /var/www/html
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache --virtual .build-deps=0 \
 		$PHPIZE_DEPS \
 		freetype-dev \
 		icu-dev \
@@ -76,7 +80,7 @@ RUN set -ex; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --no-network --virtual .wordpress-phpexts-rundeps $runDeps; \
+	apk add --no-network --virtual .wordpress-phpexts-rundeps=0 $runDeps; \
 	apk del --no-network .build-deps; \
 	\
 	! { ldd "$extDir"/*.so | grep 'not found'; }; \
@@ -113,7 +117,7 @@ ENV WORDPRESS_CLI_SHA512 adb12146bab8d829621efed41124dcd0012f9027f47e0228be70802
 
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .fetch-deps \
+	apk add --no-cache --virtual .fetch-deps=0 \
 		gnupg \
 	; \
 	\

--- a/latest/php8.1/apache/Dockerfile
+++ b/latest/php8.1/apache/Dockerfile
@@ -6,6 +6,10 @@
 
 FROM php:8.1-apache
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 # persistent dependencies
 RUN set -eux; \
 	apt-get update; \
@@ -13,7 +17,9 @@ RUN set -eux; \
 # Ghostscript is required for rendering PDF previews
 		ghostscript \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/* ; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
@@ -81,6 +87,8 @@ RUN set -ex; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache; \
 	\
 	! { ldd "$extDir"/*.so | grep 'not found'; }; \
 # check for output like "PHP Warning:  PHP Startup: Unable to load dynamic library 'foo' (tried: ...)

--- a/latest/php8.1/fpm-alpine/Dockerfile
+++ b/latest/php8.1/fpm-alpine/Dockerfile
@@ -6,6 +6,10 @@
 
 FROM php:8.1-fpm-alpine
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 # persistent dependencies
 RUN set -eux; \
 	apk add --no-cache \
@@ -15,12 +19,14 @@ RUN set -eux; \
 		ghostscript \
 # Alpine package for "imagemagick" contains ~120 .so files, see: https://github.com/docker-library/wordpress/pull/497
 		imagemagick \
-	;
+	; \
+# clean up for reproducibility
+	rm -rf /var/cache/fontconfig
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache --virtual .build-deps=0 \
 		$PHPIZE_DEPS \
 		freetype-dev \
 		icu-dev \
@@ -75,7 +81,7 @@ RUN set -ex; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --no-network --virtual .wordpress-phpexts-rundeps $runDeps; \
+	apk add --no-network --virtual .wordpress-phpexts-rundeps=0 $runDeps; \
 	apk del --no-network .build-deps; \
 	\
 	! { ldd "$extDir"/*.so | grep 'not found'; }; \

--- a/latest/php8.1/fpm/Dockerfile
+++ b/latest/php8.1/fpm/Dockerfile
@@ -6,6 +6,10 @@
 
 FROM php:8.1-fpm
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 # persistent dependencies
 RUN set -eux; \
 	apt-get update; \
@@ -13,7 +17,9 @@ RUN set -eux; \
 # Ghostscript is required for rendering PDF previews
 		ghostscript \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/* ; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
@@ -81,6 +87,8 @@ RUN set -ex; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache; \
 	\
 	! { ldd "$extDir"/*.so | grep 'not found'; }; \
 # check for output like "PHP Warning:  PHP Startup: Unable to load dynamic library 'foo' (tried: ...)

--- a/latest/php8.2/apache/Dockerfile
+++ b/latest/php8.2/apache/Dockerfile
@@ -6,6 +6,10 @@
 
 FROM php:8.2-apache
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 # persistent dependencies
 RUN set -eux; \
 	apt-get update; \
@@ -13,7 +17,9 @@ RUN set -eux; \
 # Ghostscript is required for rendering PDF previews
 		ghostscript \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/* ; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
@@ -81,6 +87,8 @@ RUN set -ex; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache; \
 	\
 	! { ldd "$extDir"/*.so | grep 'not found'; }; \
 # check for output like "PHP Warning:  PHP Startup: Unable to load dynamic library 'foo' (tried: ...)

--- a/latest/php8.2/fpm-alpine/Dockerfile
+++ b/latest/php8.2/fpm-alpine/Dockerfile
@@ -6,6 +6,10 @@
 
 FROM php:8.2-fpm-alpine
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 # persistent dependencies
 RUN set -eux; \
 	apk add --no-cache \
@@ -15,12 +19,14 @@ RUN set -eux; \
 		ghostscript \
 # Alpine package for "imagemagick" contains ~120 .so files, see: https://github.com/docker-library/wordpress/pull/497
 		imagemagick \
-	;
+	; \
+# clean up for reproducibility
+	rm -rf /var/cache/fontconfig
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache --virtual .build-deps=0 \
 		$PHPIZE_DEPS \
 		freetype-dev \
 		icu-dev \
@@ -75,7 +81,7 @@ RUN set -ex; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --no-network --virtual .wordpress-phpexts-rundeps $runDeps; \
+	apk add --no-network --virtual .wordpress-phpexts-rundeps=0 $runDeps; \
 	apk del --no-network .build-deps; \
 	\
 	! { ldd "$extDir"/*.so | grep 'not found'; }; \

--- a/latest/php8.2/fpm/Dockerfile
+++ b/latest/php8.2/fpm/Dockerfile
@@ -6,6 +6,10 @@
 
 FROM php:8.2-fpm
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 # persistent dependencies
 RUN set -eux; \
 	apt-get update; \
@@ -13,7 +17,9 @@ RUN set -eux; \
 # Ghostscript is required for rendering PDF previews
 		ghostscript \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/* ; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
@@ -81,6 +87,8 @@ RUN set -ex; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache; \
 	\
 	! { ldd "$extDir"/*.so | grep 'not found'; }; \
 # check for output like "PHP Warning:  PHP Startup: Unable to load dynamic library 'foo' (tried: ...)

--- a/latest/php8.3/apache/Dockerfile
+++ b/latest/php8.3/apache/Dockerfile
@@ -6,6 +6,10 @@
 
 FROM php:8.3-apache
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 # persistent dependencies
 RUN set -eux; \
 	apt-get update; \
@@ -13,7 +17,9 @@ RUN set -eux; \
 # Ghostscript is required for rendering PDF previews
 		ghostscript \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/* ; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
@@ -81,6 +87,8 @@ RUN set -ex; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache; \
 	\
 	! { ldd "$extDir"/*.so | grep 'not found'; }; \
 # check for output like "PHP Warning:  PHP Startup: Unable to load dynamic library 'foo' (tried: ...)

--- a/latest/php8.3/fpm-alpine/Dockerfile
+++ b/latest/php8.3/fpm-alpine/Dockerfile
@@ -6,6 +6,10 @@
 
 FROM php:8.3-fpm-alpine
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 # persistent dependencies
 RUN set -eux; \
 	apk add --no-cache \
@@ -15,12 +19,14 @@ RUN set -eux; \
 		ghostscript \
 # Alpine package for "imagemagick" contains ~120 .so files, see: https://github.com/docker-library/wordpress/pull/497
 		imagemagick \
-	;
+	; \
+# clean up for reproducibility
+	rm -rf /var/cache/fontconfig
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache --virtual .build-deps=0 \
 		$PHPIZE_DEPS \
 		freetype-dev \
 		icu-dev \
@@ -75,7 +81,7 @@ RUN set -ex; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --no-network --virtual .wordpress-phpexts-rundeps $runDeps; \
+	apk add --no-network --virtual .wordpress-phpexts-rundeps=0 $runDeps; \
 	apk del --no-network .build-deps; \
 	\
 	! { ldd "$extDir"/*.so | grep 'not found'; }; \

--- a/latest/php8.3/fpm/Dockerfile
+++ b/latest/php8.3/fpm/Dockerfile
@@ -6,6 +6,10 @@
 
 FROM php:8.3-fpm
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 # persistent dependencies
 RUN set -eux; \
 	apt-get update; \
@@ -13,7 +17,9 @@ RUN set -eux; \
 # Ghostscript is required for rendering PDF previews
 		ghostscript \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/* ; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
 RUN set -ex; \
@@ -81,6 +87,8 @@ RUN set -ex; \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*; \
+# clean up for reproducibility
+	rm -rf /var/log/* /var/cache/ldconfig/aux-cache; \
 	\
 	! { ldd "$extDir"/*.so | grep 'not found'; }; \
 # check for output like "PHP Warning:  PHP Startup: Unable to load dynamic library 'foo' (tried: ...)


### PR DESCRIPTION
See:
- docker-library/official-images#16044

- - -

- `SOURCE_DATE_EPOCH` is added. The value is consumed by the build scripts to make the binary reproducible.

- For Debian, `/var/log/*` is removed as they contain timestamps

- For Debian, `/var/cache/ldconfig/aux-cache` is removed as they contain inode numbers, etc.

- For Alpine, virtual package versions are pinned to "0" to eliminate the timestamp-based version numbers that appear in `/etc/apk/world` and `/lib/apk/db/installed`

- For Alpine, `/var/cache/fontconfig` is removed

> [!NOTE]
> The following topics are NOT covered by this commit:
>
> - To reproduce file timestamps in layers, BuildKit has to be executed with
>   `--output type=<TYPE>,rewrite-timestamp=true`.
>   Needs BuildKit v0.13 or later.
>
> - To reproduce the base image by the hash, reproducers may:
>   - modify the `FROM` instruction in Dockerfile manually
>   - or, use the `CONVERT` action of source policies to replace the base image.
>     <https://github.com/moby/buildkit/blob/v0.13.2/docs/build-repro.md>
>
> - To reproduce packages, see the `RUN` instruction hook proposed in
>   moby/buildkit#4576