### PR TITLE
Disable tar extract file modified time

### DIFF
--- a/beta/php8.1/apache/docker-entrypoint.sh
+++ b/beta/php8.1/apache/docker-entrypoint.sh
@@ -47,7 +47,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		)
 		if [ "$uid" != '0' ]; then
 			# avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
-			targetTarArgs+=( --no-overwrite-dir )
+			targetTarArgs+=( 
+				--no-overwrite-dir
+				--touch
+			)
 		fi
 		# loop over "pluggable" content in the source, and if it already exists in the destination, skip it
 		# https://github.com/docker-library/wordpress/issues/506 ("wp-content" persisted, "akismet" updated, WordPress container restarted/recreated, "akismet" downgraded)

--- a/beta/php8.1/fpm-alpine/docker-entrypoint.sh
+++ b/beta/php8.1/fpm-alpine/docker-entrypoint.sh
@@ -47,7 +47,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		)
 		if [ "$uid" != '0' ]; then
 			# avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
-			targetTarArgs+=( --no-overwrite-dir )
+			targetTarArgs+=( 
+				--no-overwrite-dir
+				--touch
+			)
 		fi
 		# loop over "pluggable" content in the source, and if it already exists in the destination, skip it
 		# https://github.com/docker-library/wordpress/issues/506 ("wp-content" persisted, "akismet" updated, WordPress container restarted/recreated, "akismet" downgraded)

--- a/beta/php8.1/fpm/docker-entrypoint.sh
+++ b/beta/php8.1/fpm/docker-entrypoint.sh
@@ -47,7 +47,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		)
 		if [ "$uid" != '0' ]; then
 			# avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
-			targetTarArgs+=( --no-overwrite-dir )
+			targetTarArgs+=( 
+				--no-overwrite-dir
+				--touch
+			)
 		fi
 		# loop over "pluggable" content in the source, and if it already exists in the destination, skip it
 		# https://github.com/docker-library/wordpress/issues/506 ("wp-content" persisted, "akismet" updated, WordPress container restarted/recreated, "akismet" downgraded)

--- a/beta/php8.2/apache/docker-entrypoint.sh
+++ b/beta/php8.2/apache/docker-entrypoint.sh
@@ -47,7 +47,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		)
 		if [ "$uid" != '0' ]; then
 			# avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
-			targetTarArgs+=( --no-overwrite-dir )
+			targetTarArgs+=( 
+				--no-overwrite-dir
+				--touch
+			)
 		fi
 		# loop over "pluggable" content in the source, and if it already exists in the destination, skip it
 		# https://github.com/docker-library/wordpress/issues/506 ("wp-content" persisted, "akismet" updated, WordPress container restarted/recreated, "akismet" downgraded)

--- a/beta/php8.2/fpm-alpine/docker-entrypoint.sh
+++ b/beta/php8.2/fpm-alpine/docker-entrypoint.sh
@@ -47,7 +47,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		)
 		if [ "$uid" != '0' ]; then
 			# avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
-			targetTarArgs+=( --no-overwrite-dir )
+			targetTarArgs+=( 
+				--no-overwrite-dir
+				--touch
+			)
 		fi
 		# loop over "pluggable" content in the source, and if it already exists in the destination, skip it
 		# https://github.com/docker-library/wordpress/issues/506 ("wp-content" persisted, "akismet" updated, WordPress container restarted/recreated, "akismet" downgraded)

--- a/beta/php8.2/fpm/docker-entrypoint.sh
+++ b/beta/php8.2/fpm/docker-entrypoint.sh
@@ -47,7 +47,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		)
 		if [ "$uid" != '0' ]; then
 			# avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
-			targetTarArgs+=( --no-overwrite-dir )
+			targetTarArgs+=( 
+				--no-overwrite-dir
+				--touch
+			)
 		fi
 		# loop over "pluggable" content in the source, and if it already exists in the destination, skip it
 		# https://github.com/docker-library/wordpress/issues/506 ("wp-content" persisted, "akismet" updated, WordPress container restarted/recreated, "akismet" downgraded)

--- a/beta/php8.3/apache/docker-entrypoint.sh
+++ b/beta/php8.3/apache/docker-entrypoint.sh
@@ -47,7 +47,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		)
 		if [ "$uid" != '0' ]; then
 			# avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
-			targetTarArgs+=( --no-overwrite-dir )
+			targetTarArgs+=( 
+				--no-overwrite-dir
+				--touch
+			)
 		fi
 		# loop over "pluggable" content in the source, and if it already exists in the destination, skip it
 		# https://github.com/docker-library/wordpress/issues/506 ("wp-content" persisted, "akismet" updated, WordPress container restarted/recreated, "akismet" downgraded)

--- a/beta/php8.3/fpm-alpine/docker-entrypoint.sh
+++ b/beta/php8.3/fpm-alpine/docker-entrypoint.sh
@@ -47,7 +47,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		)
 		if [ "$uid" != '0' ]; then
 			# avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
-			targetTarArgs+=( --no-overwrite-dir )
+			targetTarArgs+=( 
+				--no-overwrite-dir
+				--touch
+			)
 		fi
 		# loop over "pluggable" content in the source, and if it already exists in the destination, skip it
 		# https://github.com/docker-library/wordpress/issues/506 ("wp-content" persisted, "akismet" updated, WordPress container restarted/recreated, "akismet" downgraded)

--- a/beta/php8.3/fpm/docker-entrypoint.sh
+++ b/beta/php8.3/fpm/docker-entrypoint.sh
@@ -47,7 +47,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		)
 		if [ "$uid" != '0' ]; then
 			# avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
-			targetTarArgs+=( --no-overwrite-dir )
+			targetTarArgs+=( 
+				--no-overwrite-dir
+				--touch
+			)
 		fi
 		# loop over "pluggable" content in the source, and if it already exists in the destination, skip it
 		# https://github.com/docker-library/wordpress/issues/506 ("wp-content" persisted, "akismet" updated, WordPress container restarted/recreated, "akismet" downgraded)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -47,7 +47,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		)
 		if [ "$uid" != '0' ]; then
 			# avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
-			targetTarArgs+=( --no-overwrite-dir )
+			targetTarArgs+=( 
+				--no-overwrite-dir
+				--touch
+			)
 		fi
 		# loop over "pluggable" content in the source, and if it already exists in the destination, skip it
 		# https://github.com/docker-library/wordpress/issues/506 ("wp-content" persisted, "akismet" updated, WordPress container restarted/recreated, "akismet" downgraded)

--- a/latest/php8.1/apache/docker-entrypoint.sh
+++ b/latest/php8.1/apache/docker-entrypoint.sh
@@ -47,7 +47,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		)
 		if [ "$uid" != '0' ]; then
 			# avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
-			targetTarArgs+=( --no-overwrite-dir )
+			targetTarArgs+=( 
+				--no-overwrite-dir
+				--touch
+			)
 		fi
 		# loop over "pluggable" content in the source, and if it already exists in the destination, skip it
 		# https://github.com/docker-library/wordpress/issues/506 ("wp-content" persisted, "akismet" updated, WordPress container restarted/recreated, "akismet" downgraded)

--- a/latest/php8.1/fpm-alpine/docker-entrypoint.sh
+++ b/latest/php8.1/fpm-alpine/docker-entrypoint.sh
@@ -47,7 +47,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		)
 		if [ "$uid" != '0' ]; then
 			# avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
-			targetTarArgs+=( --no-overwrite-dir )
+			targetTarArgs+=( 
+				--no-overwrite-dir
+				--touch
+			)
 		fi
 		# loop over "pluggable" content in the source, and if it already exists in the destination, skip it
 		# https://github.com/docker-library/wordpress/issues/506 ("wp-content" persisted, "akismet" updated, WordPress container restarted/recreated, "akismet" downgraded)

--- a/latest/php8.1/fpm/docker-entrypoint.sh
+++ b/latest/php8.1/fpm/docker-entrypoint.sh
@@ -47,7 +47,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		)
 		if [ "$uid" != '0' ]; then
 			# avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
-			targetTarArgs+=( --no-overwrite-dir )
+			targetTarArgs+=( 
+				--no-overwrite-dir
+				--touch
+			)
 		fi
 		# loop over "pluggable" content in the source, and if it already exists in the destination, skip it
 		# https://github.com/docker-library/wordpress/issues/506 ("wp-content" persisted, "akismet" updated, WordPress container restarted/recreated, "akismet" downgraded)

--- a/latest/php8.2/apache/docker-entrypoint.sh
+++ b/latest/php8.2/apache/docker-entrypoint.sh
@@ -47,7 +47,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		)
 		if [ "$uid" != '0' ]; then
 			# avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
-			targetTarArgs+=( --no-overwrite-dir )
+			targetTarArgs+=( 
+				--no-overwrite-dir
+				--touch
+			)
 		fi
 		# loop over "pluggable" content in the source, and if it already exists in the destination, skip it
 		# https://github.com/docker-library/wordpress/issues/506 ("wp-content" persisted, "akismet" updated, WordPress container restarted/recreated, "akismet" downgraded)

--- a/latest/php8.2/fpm-alpine/docker-entrypoint.sh
+++ b/latest/php8.2/fpm-alpine/docker-entrypoint.sh
@@ -47,7 +47,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		)
 		if [ "$uid" != '0' ]; then
 			# avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
-			targetTarArgs+=( --no-overwrite-dir )
+			targetTarArgs+=( 
+				--no-overwrite-dir
+				--touch
+			)
 		fi
 		# loop over "pluggable" content in the source, and if it already exists in the destination, skip it
 		# https://github.com/docker-library/wordpress/issues/506 ("wp-content" persisted, "akismet" updated, WordPress container restarted/recreated, "akismet" downgraded)

--- a/latest/php8.2/fpm/docker-entrypoint.sh
+++ b/latest/php8.2/fpm/docker-entrypoint.sh
@@ -47,7 +47,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		)
 		if [ "$uid" != '0' ]; then
 			# avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
-			targetTarArgs+=( --no-overwrite-dir )
+			targetTarArgs+=( 
+				--no-overwrite-dir
+				--touch
+			)
 		fi
 		# loop over "pluggable" content in the source, and if it already exists in the destination, skip it
 		# https://github.com/docker-library/wordpress/issues/506 ("wp-content" persisted, "akismet" updated, WordPress container restarted/recreated, "akismet" downgraded)

--- a/latest/php8.3/apache/docker-entrypoint.sh
+++ b/latest/php8.3/apache/docker-entrypoint.sh
@@ -47,7 +47,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		)
 		if [ "$uid" != '0' ]; then
 			# avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
-			targetTarArgs+=( --no-overwrite-dir )
+			targetTarArgs+=( 
+				--no-overwrite-dir
+				--touch
+			)
 		fi
 		# loop over "pluggable" content in the source, and if it already exists in the destination, skip it
 		# https://github.com/docker-library/wordpress/issues/506 ("wp-content" persisted, "akismet" updated, WordPress container restarted/recreated, "akismet" downgraded)

--- a/latest/php8.3/fpm-alpine/docker-entrypoint.sh
+++ b/latest/php8.3/fpm-alpine/docker-entrypoint.sh
@@ -47,7 +47,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		)
 		if [ "$uid" != '0' ]; then
 			# avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
-			targetTarArgs+=( --no-overwrite-dir )
+			targetTarArgs+=( 
+				--no-overwrite-dir
+				--touch
+			)
 		fi
 		# loop over "pluggable" content in the source, and if it already exists in the destination, skip it
 		# https://github.com/docker-library/wordpress/issues/506 ("wp-content" persisted, "akismet" updated, WordPress container restarted/recreated, "akismet" downgraded)

--- a/latest/php8.3/fpm/docker-entrypoint.sh
+++ b/latest/php8.3/fpm/docker-entrypoint.sh
@@ -47,7 +47,10 @@ if [[ "$1" == apache2* ]] || [ "$1" = 'php-fpm' ]; then
 		)
 		if [ "$uid" != '0' ]; then
 			# avoid "tar: .: Cannot utime: Operation not permitted" and "tar: .: Cannot change mode to rwxr-xr-x: Operation not permitted"
-			targetTarArgs+=( --no-overwrite-dir )
+			targetTarArgs+=( 
+				--no-overwrite-dir
+				--touch
+			)
 		fi
 		# loop over "pluggable" content in the source, and if it already exists in the destination, skip it
 		# https://github.com/docker-library/wordpress/issues/506 ("wp-content" persisted, "akismet" updated, WordPress container restarted/recreated, "akismet" downgraded)


### PR DESCRIPTION
I added the --touch flag as targetTarArgs to prevent the "Cannot utime: Operation not supported" error message from appearing, especially when some storage types (e.g. Azure FileShare) are used on Kubernetes.