### PR TITLE
Replace PECL with PIE

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -44,7 +44,8 @@ WORKDIR /var/www/html
 {{ ) end -}}
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 {{ if is_alpine then ( -}}
 	apk add --no-cache --virtual .build-deps \
@@ -91,10 +92,9 @@ RUN set -ex; \
 {{ if is_alpine then ( -}}
 # WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
 {{ ) else "" end -}}
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/beta/php8.2/apache/Dockerfile
+++ b/beta/php8.2/apache/Dockerfile
@@ -20,7 +20,8 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
 	\
@@ -50,10 +51,9 @@ RUN set -ex; \
 		mysqli \
 		zip \
 	; \
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/beta/php8.2/fpm-alpine/Dockerfile
+++ b/beta/php8.2/fpm-alpine/Dockerfile
@@ -18,7 +18,8 @@ RUN set -eux; \
 	;
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
@@ -47,10 +48,9 @@ RUN set -ex; \
 		zip \
 	; \
 # WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/beta/php8.2/fpm/Dockerfile
+++ b/beta/php8.2/fpm/Dockerfile
@@ -20,7 +20,8 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
 	\
@@ -50,10 +51,9 @@ RUN set -ex; \
 		mysqli \
 		zip \
 	; \
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/beta/php8.3/apache/Dockerfile
+++ b/beta/php8.3/apache/Dockerfile
@@ -20,7 +20,8 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
 	\
@@ -50,10 +51,9 @@ RUN set -ex; \
 		mysqli \
 		zip \
 	; \
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/beta/php8.3/fpm-alpine/Dockerfile
+++ b/beta/php8.3/fpm-alpine/Dockerfile
@@ -18,7 +18,8 @@ RUN set -eux; \
 	;
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
@@ -47,10 +48,9 @@ RUN set -ex; \
 		zip \
 	; \
 # WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/beta/php8.3/fpm/Dockerfile
+++ b/beta/php8.3/fpm/Dockerfile
@@ -20,7 +20,8 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
 	\
@@ -50,10 +51,9 @@ RUN set -ex; \
 		mysqli \
 		zip \
 	; \
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/beta/php8.4/apache/Dockerfile
+++ b/beta/php8.4/apache/Dockerfile
@@ -20,7 +20,8 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
 	\
@@ -50,10 +51,9 @@ RUN set -ex; \
 		mysqli \
 		zip \
 	; \
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/beta/php8.4/fpm-alpine/Dockerfile
+++ b/beta/php8.4/fpm-alpine/Dockerfile
@@ -18,7 +18,8 @@ RUN set -eux; \
 	;
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
@@ -47,10 +48,9 @@ RUN set -ex; \
 		zip \
 	; \
 # WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/beta/php8.4/fpm/Dockerfile
+++ b/beta/php8.4/fpm/Dockerfile
@@ -20,7 +20,8 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
 	\
@@ -50,10 +51,9 @@ RUN set -ex; \
 		mysqli \
 		zip \
 	; \
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/beta/php8.5/apache/Dockerfile
+++ b/beta/php8.5/apache/Dockerfile
@@ -20,7 +20,8 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
 	\
@@ -50,10 +51,9 @@ RUN set -ex; \
 		mysqli \
 		zip \
 	; \
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/beta/php8.5/fpm-alpine/Dockerfile
+++ b/beta/php8.5/fpm-alpine/Dockerfile
@@ -18,7 +18,8 @@ RUN set -eux; \
 	;
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
@@ -47,10 +48,9 @@ RUN set -ex; \
 		zip \
 	; \
 # WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/beta/php8.5/fpm/Dockerfile
+++ b/beta/php8.5/fpm/Dockerfile
@@ -20,7 +20,8 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
 	\
@@ -50,10 +51,9 @@ RUN set -ex; \
 		mysqli \
 		zip \
 	; \
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/cli/php8.2/alpine/Dockerfile
+++ b/cli/php8.2/alpine/Dockerfile
@@ -19,7 +19,8 @@ RUN set -ex; \
 WORKDIR /var/www/html
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
@@ -48,10 +49,9 @@ RUN set -ex; \
 		zip \
 	; \
 # WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/cli/php8.3/alpine/Dockerfile
+++ b/cli/php8.3/alpine/Dockerfile
@@ -19,7 +19,8 @@ RUN set -ex; \
 WORKDIR /var/www/html
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
@@ -48,10 +49,9 @@ RUN set -ex; \
 		zip \
 	; \
 # WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/cli/php8.4/alpine/Dockerfile
+++ b/cli/php8.4/alpine/Dockerfile
@@ -19,7 +19,8 @@ RUN set -ex; \
 WORKDIR /var/www/html
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
@@ -48,10 +49,9 @@ RUN set -ex; \
 		zip \
 	; \
 # WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/cli/php8.5/alpine/Dockerfile
+++ b/cli/php8.5/alpine/Dockerfile
@@ -19,7 +19,8 @@ RUN set -ex; \
 WORKDIR /var/www/html
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
@@ -48,10 +49,9 @@ RUN set -ex; \
 		zip \
 	; \
 # WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/latest/php8.2/apache/Dockerfile
+++ b/latest/php8.2/apache/Dockerfile
@@ -20,7 +20,8 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
 	\
@@ -50,10 +51,9 @@ RUN set -ex; \
 		mysqli \
 		zip \
 	; \
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/latest/php8.2/fpm-alpine/Dockerfile
+++ b/latest/php8.2/fpm-alpine/Dockerfile
@@ -18,7 +18,8 @@ RUN set -eux; \
 	;
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
@@ -47,10 +48,9 @@ RUN set -ex; \
 		zip \
 	; \
 # WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/latest/php8.2/fpm/Dockerfile
+++ b/latest/php8.2/fpm/Dockerfile
@@ -20,7 +20,8 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
 	\
@@ -50,10 +51,9 @@ RUN set -ex; \
 		mysqli \
 		zip \
 	; \
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/latest/php8.3/apache/Dockerfile
+++ b/latest/php8.3/apache/Dockerfile
@@ -20,7 +20,8 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
 	\
@@ -50,10 +51,9 @@ RUN set -ex; \
 		mysqli \
 		zip \
 	; \
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/latest/php8.3/fpm-alpine/Dockerfile
+++ b/latest/php8.3/fpm-alpine/Dockerfile
@@ -18,7 +18,8 @@ RUN set -eux; \
 	;
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
@@ -47,10 +48,9 @@ RUN set -ex; \
 		zip \
 	; \
 # WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/latest/php8.3/fpm/Dockerfile
+++ b/latest/php8.3/fpm/Dockerfile
@@ -20,7 +20,8 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
 	\
@@ -50,10 +51,9 @@ RUN set -ex; \
 		mysqli \
 		zip \
 	; \
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/latest/php8.4/apache/Dockerfile
+++ b/latest/php8.4/apache/Dockerfile
@@ -20,7 +20,8 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
 	\
@@ -50,10 +51,9 @@ RUN set -ex; \
 		mysqli \
 		zip \
 	; \
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/latest/php8.4/fpm-alpine/Dockerfile
+++ b/latest/php8.4/fpm-alpine/Dockerfile
@@ -18,7 +18,8 @@ RUN set -eux; \
 	;
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
@@ -47,10 +48,9 @@ RUN set -ex; \
 		zip \
 	; \
 # WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/latest/php8.4/fpm/Dockerfile
+++ b/latest/php8.4/fpm/Dockerfile
@@ -20,7 +20,8 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
 	\
@@ -50,10 +51,9 @@ RUN set -ex; \
 		mysqli \
 		zip \
 	; \
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/latest/php8.5/apache/Dockerfile
+++ b/latest/php8.5/apache/Dockerfile
@@ -20,7 +20,8 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
 	\
@@ -50,10 +51,9 @@ RUN set -ex; \
 		mysqli \
 		zip \
 	; \
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/latest/php8.5/fpm-alpine/Dockerfile
+++ b/latest/php8.5/fpm-alpine/Dockerfile
@@ -18,7 +18,8 @@ RUN set -eux; \
 	;
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
@@ -47,10 +48,9 @@ RUN set -ex; \
 		zip \
 	; \
 # WARNING: imagick is likely not supported on Alpine: https://github.com/Imagick/imagick/issues/328
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/latest/php8.5/fpm/Dockerfile
+++ b/latest/php8.5/fpm/Dockerfile
@@ -20,7 +20,8 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 # install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
-RUN set -ex; \
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+	set -ex; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
 	\
@@ -50,10 +51,9 @@ RUN set -ex; \
 		mysqli \
 		zip \
 	; \
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.8.1; \
+# https://packagist.org/packages/imagick/imagick
+	pie install imagick/imagick:3.8.1; \
 	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \


### PR DESCRIPTION
This PR aims to replace PECL with PIE. I've opted for using bind mount for pie to not bloat the image with pie executable. 

If we'd like to keep pie in the image then we can replace the bind mount with:

```dockerfile
COPY --from=ghcr.io/php/pie:bin /pie /usr/local/bin/pie
```

The executable is around 12 MB.

Other caveats are that PHP base image is compiled with pear support so the PECL itself is still there. 

Let me know if this PR is acceptable or you require any changes.